### PR TITLE
Add docs/dev-log decision logs to the feature workflow

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -5,7 +5,7 @@ description: TimeScope feature loop — use when discussing a GitHub issue, star
 
 # Feature Loop (issue → PR → develop)
 
-The durable record is the GitHub issue + the PR description. No spec files.
+The durable record is the GitHub issue + the PR description + a short `docs/dev-log/` decision log. No heavyweight up-front spec files.
 
 ## 1. Discuss
 
@@ -24,6 +24,8 @@ git checkout -b feature/issue-<N>-<short-slug>
 ## 3. Plan
 
 Plan in conversation (use plan mode for non-trivial changes). Identify exact files, tests, and any impact on: the session state machine, the dashboard/webview, data formats (`docs/record_format_spec.md`), or commands/settings in `package.json` (needs explicit approval).
+
+Start the dev log now: copy [docs/dev-log/TEMPLATE.md](../../../docs/dev-log/TEMPLATE.md) to `docs/dev-log/issue-<N>-<short-slug>.md` and fill in the problem + the scope decisions and trade-offs as they're agreed. It's a living decision log through implementation, not a spec — keep it short.
 
 ## 4. Implement
 
@@ -47,6 +49,7 @@ Plan in conversation (use plan mode for non-trivial changes). Identify exact fil
   - JSONL canonical field order and format version header untouched unless the spec docs change too
 - [ ] Propose a version bump (patch/minor per [coding_standards.md](../../../coding_standards.md) Versioning rules) with the explicit `from → to`; on user confirmation, edit `package.json`'s `version` and include it in the PR. Never bump silently.
 - [ ] One line added to `CHANGELOG.md` under **Unreleased**
+- [ ] `docs/dev-log/issue-<N>-<slug>.md` finalized: retrospective filled in (what actually shipped, any changes from the plan), issue/PR links set
 
 ## 6. Hand off for F5
 
@@ -59,7 +62,7 @@ git push -u origin <branch>
 gh pr create --base develop --title "<concise title>" --body "<description>"
 ```
 
-Description: summary, user-facing behavior, technical changes, `Closes #<N>`. Include a small mermaid diagram when structure changed. Keep it short and readable — no boilerplate sections that don't apply.
+Description: summary, user-facing behavior, technical changes, `Closes #<N>`, and a link to the `docs/dev-log/` entry. Include a small mermaid diagram when structure changed. Keep it short and readable — no boilerplate sections that don't apply.
 
 ## 8. After merge (offer, don't assume)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ One line per merged PR, added at PR time under **Unreleased**. At release, entri
 
 ## Unreleased
 
+- Dev logs: each feature branch keeps a short decision log in `docs/dev-log/` (started at plan time, finalized as a retrospective at PR time) — captures the *why* behind a change, not a spec (#36)
 - Build info: `npm run package` writes `out/buildinfo.json`; visible via the new **TimeScope: Show Build Info** command, the status-bar tooltip, and a dashboard footer — plus a per-PR version-bump policy so the Extensions view version reflects real progress (#35)
 - Claude-driven development process: three chat-driven workflow skills (feature / install / release), CLAUDE.md, PR CI, isolated F5 test storage; retired the legacy script-based workflow
 - Playwright UI test suite for the dashboard webview (`npm run test:ui`): renders the real dashboard against fixture data, covering charts, filters, session table, and the edit-modal round-trip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,4 @@ Full list: [coding_standards.md](coding_standards.md). The load-bearing ones:
 - Keep docs short, human-readable, and diagram-first — a good mermaid block diagram beats pages of text
 - When a change alters architecture, the state machine, or data formats: update the relevant diagram in [docs/processes.md](docs/processes.md)
 - Every PR adds one line to `CHANGELOG.md` under "Unreleased"
+- Every feature branch keeps a short decision log in [docs/dev-log/](docs/dev-log/) (`issue-<N>-<slug>.md`, from `TEMPLATE.md`): started at plan time, finalized as a retrospective at PR time. It captures the *why* — decisions, trade-offs, rejected approaches — not a spec. This is the log the "no heavyweight spec files" rule leaves room for, not an exception to it.

--- a/docs/dev-log/TEMPLATE.md
+++ b/docs/dev-log/TEMPLATE.md
@@ -1,0 +1,22 @@
+# Issue #<N> — <title>
+
+> Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
+> Keep it short — capture the *why*, not a blow-by-blow. Skip any section that doesn't apply.
+
+**Issue:** <link>  ·  **PR:** <link>
+
+## Problem
+
+What wasn't working / what we're trying to enable, in a sentence or two.
+
+## Decisions & trade-offs
+
+The choices that shaped the work and why we made them — the reasoning that won't survive in the diff.
+
+## Rejected approaches
+
+Options we considered and dropped, with the reason. (Delete if none.)
+
+## Retrospective
+
+Filled in at PR time: what actually got built, anything that changed from the plan, and what a future reader should know.

--- a/docs/dev-log/issue-35-build-info.md
+++ b/docs/dev-log/issue-35-build-info.md
@@ -1,0 +1,28 @@
+# Issue #35 — Build info: show installed commit/build date across machines
+
+> Decision log, not a spec. Backfilled retrospectively (this predates the dev-log process, added in #36).
+
+**Issue:** [#35](https://github.com/Heliman84/timescope/issues/35)  ·  **PR:** [#37](https://github.com/Heliman84/timescope/pull/37)
+
+## Problem
+
+The Extensions view Version column showed the same `0.2.0` for every dev build, and there was no way to tell which commit/branch/date was actually installed on a given machine. The original issue framed this as "ship `out/buildinfo.json` in the .vsix"; discussion reframed the real core as **"we aren't seeing useful version information."**
+
+## Decisions & trade-offs
+
+- **The Extensions-view Version column can't move without a real manifest bump.** VS Code reads it straight from `package.json` and forbids semver suffixes like `0.2.0-dev.<sha>`. `buildinfo.json` is a *complementary* surface, not a fix to that column — so we also needed a version-bump policy, not just the file.
+- **Bump per PR, not only at release.** Every feature/bugfix PR bumps `package.json` (patch/minor; major pinned at `0` until a deliberate promotion). This keeps `develop`'s version continuously meaningful so the Extensions view reflects progress. Decoupled from actually building a `.vsix` — the install/release skills package whatever version is current, so per-PR bumping adds no build churn.
+- **Confirm every bump `from → to`.** The user must approve the exact version transition; never bump silently. Recorded in `coding_standards.md` and enforced via the feature/release skill checklists.
+- **Surface build info where the user actually looks**, not just the command palette: status-bar tooltip + dashboard footer, with the "Show Build Info" command as a secondary surface.
+- **`format_build_info_full` composed from `format_status_bar_suffix`** rather than duplicating the version/sha construction — one source of truth for the shared prefix (code-review finding).
+- **Write `buildinfo.json` in `vscode:prepublish`, not just `package`.** Caught during F5: the footer showed a stale `0.2.0` because prepublish (which F5's prelaunch task runs) never regenerated the file. Moving `write-buildinfo` into prepublish means F5, `npm test`, and `npm run package` all read a current file.
+- **Git failures in `write_buildinfo.js` degrade to `"unknown"`**, matching the reader's graceful-null philosophy — build metadata is best-effort display, never load-bearing.
+
+## Rejected approaches
+
+- **Keep bumping only at release.** Rejected: dev builds would stay same-version between releases, which is exactly the "no useful version info" gap the issue is about.
+- **Separate `build_info` postMessage to the webview.** Considered during altitude review; kept it as a sibling field on the existing `summary_data` message since build info is static for the panel's lifetime and a separate message added ceremony without benefit.
+
+## Retrospective
+
+Shipped as designed plus the two mid-flight fixes above (prepublish timing, git hardening), both surfaced by F5 and code review rather than up front. Field named `build_date` (snake_case) to match the persisted-record convention. Also folded in process controls born from a mistake this session — a pre-commit hook blocking direct commits to `develop`/`main`, and a CLAUDE.md rule that an "Other" answer to a clarifying question isn't consent. Version landed at **0.3.0**.

--- a/docs/dev-log/issue-36-dev-log.md
+++ b/docs/dev-log/issue-36-dev-log.md
@@ -1,0 +1,26 @@
+# Issue #36 — Add per-branch/PR development log documents under docs/
+
+> Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
+
+**Issue:** [#36](https://github.com/Heliman84/timescope/issues/36)  ·  **PR:** *pending*
+
+## Problem
+
+The durable record was just the GitHub issue + PR description — good for *what* changed, but the reasoning that shaped scope (options weighed, trade-offs, rejected approaches) evaporated once an issue closed and scrolled off. The #35 scope debate and versioning-policy discussion were the motivating example.
+
+## Decisions & trade-offs
+
+- **Convention:** `docs/dev-log/issue-<N>-<slug>.md`, one per feature branch.
+- **Lifecycle:** created at *plan time* as a living doc, revised into a *retrospective* at PR time. Not a heavyweight up-front spec — it grows with the work.
+- **Reconcile the old "No spec files" rule by replacing, not deleting it.** That rule was reacting to the previous workflow's large, cumbersome specification files. This log is explicitly the opposite (short, decision-focused), so the line becomes "issue + PR + short dev-log; no *heavyweight* spec files" — keeping the anti-bloat intent while making room for the log.
+- **Lightweight skeleton template** (Problem / Decisions & trade-offs / Rejected approaches / Retrospective), sections skippable — chosen over a detailed template to avoid re-introducing the bloat the old rule fought.
+- **Backfill #35** as a worked example and to capture its reasoning before it's gone.
+
+## Rejected approaches
+
+- **Detailed, prescriptive template** — rejected as bloat risk (see above).
+- **Write the log only at PR time** — rejected; capturing decisions live at plan time is the whole point, since that's when the reasoning exists.
+
+## Retrospective
+
+Shipped as planned — pure docs/skills change, no runtime surface, so no F5 check applied (a note worth carrying: the feature loop's F5 handoff doesn't fit process-only PRs). Deliverables: `TEMPLATE.md`, the backfilled #35 log, this log (dogfooding the process on its own PR), and the reworded "no heavyweight spec files" line across `feature/SKILL.md` and `CLAUDE.md`. The only "no spec files" reference actually lived in `feature/SKILL.md`, not `CLAUDE.md` as the issue guessed — reconciled in the one place it existed.

--- a/docs/dev-log/issue-36-dev-log.md
+++ b/docs/dev-log/issue-36-dev-log.md
@@ -2,7 +2,7 @@
 
 > Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
 
-**Issue:** [#36](https://github.com/Heliman84/timescope/issues/36)  ·  **PR:** *pending*
+**Issue:** [#36](https://github.com/Heliman84/timescope/issues/36)  ·  **PR:** [#38](https://github.com/Heliman84/timescope/pull/38)
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Feature branches now keep a short **decision log** in `docs/dev-log/` — capturing the *why* behind a change (decisions, trade-offs, rejected approaches) that otherwise evaporates once the issue closes and scrolls off. It's a decision log, not a spec.

- New `docs/dev-log/TEMPLATE.md` — lightweight skeleton: Problem / Decisions & trade-offs / Rejected approaches / Retrospective (sections skippable)
- **Lifecycle:** created at plan time as a living doc, finalized as a retrospective at PR time
- `feature/SKILL.md`: reworded the old "No spec files" line to *"issue + PR + short `docs/dev-log/` decision log; no heavyweight up-front spec files"* — keeps the anti-bloat intent while making room for the log — plus new plan-time / retrospective / link-in-PR steps
- `CLAUDE.md`: dev-log added to the documentation rules
- Backfilled `issue-35-build-info.md`; started this issue's own log (dogfooding the process on its own PR)

## Note

Pure docs/skills change — no runtime surface, so no F5 check applies.

Dev log for this change: [docs/dev-log/issue-36-dev-log.md](docs/dev-log/issue-36-dev-log.md)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)