### PR TITLE
Resolve relative global_storage_dir against the workspace folder (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ One line per merged PR, added at PR time under **Unreleased**. At release, entri
 
 ## Unreleased
 
+- `timescope.global_storage_dir`: a relative value now resolves against the first workspace folder (absolute values unchanged), so the isolated F5 test-storage setting is portable across clones and machines (#33)
 - Dev logs: each feature branch keeps a short decision log in `docs/dev-log/` (started at plan time, finalized as a retrospective at PR time) — captures the *why* behind a change, not a spec (#36)
 - Build info: `npm run package` writes `out/buildinfo.json`; visible via the new **TimeScope: Show Build Info** command, the status-bar tooltip, and a dashboard footer — plus a per-PR version-bump policy so the Extensions view version reflects real progress (#35)
 - Claude-driven development process: three chat-driven workflow skills (feature / install / release), CLAUDE.md, PR CI, isolated F5 test storage; retired the legacy script-based workflow

--- a/docs/dev-log/issue-33-relative-storage-dir.md
+++ b/docs/dev-log/issue-33-relative-storage-dir.md
@@ -3,7 +3,7 @@
 > Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
 > Keep it short — capture the *why*, not a blow-by-blow. Skip any section that doesn't apply.
 
-**Issue:** https://github.com/Heliman84/timescope/issues/33  ·  **PR:** <link>
+**Issue:** https://github.com/Heliman84/timescope/issues/33  ·  **PR:** https://github.com/Heliman84/timescope/pull/40
 
 ## Problem
 

--- a/docs/dev-log/issue-33-relative-storage-dir.md
+++ b/docs/dev-log/issue-33-relative-storage-dir.md
@@ -1,0 +1,39 @@
+# Issue #33 — paths.ts: resolve relative global_storage_dir against the workspace folder
+
+> Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
+> Keep it short — capture the *why*, not a blow-by-blow. Skip any section that doesn't apply.
+
+**Issue:** https://github.com/Heliman84/timescope/issues/33  ·  **PR:** <link>
+
+## Problem
+
+`resolve_paths` used the `timescope.global_storage_dir` setting verbatim, so isolating F5 test storage
+required committing a machine-specific absolute path in `test-workspace/.vscode/settings.json`. That path
+only exists on the original machine/clone location, silently defeating the isolation everywhere else.
+
+## Decisions & trade-offs
+
+- **Relative-path resolution only, no `${workspaceFolder}` expansion.** The issue mentions variable
+  expansion in passing, but a general variable expander is a bigger, fuzzier feature. Relative-vs-absolute
+  resolution solves the actual problem (portable test-workspace setting) with far less surface area.
+- **Relative value + no workspace folder open → fall back to VS Code's default global storage.** A relative
+  path is meaningless without a root; resolving against `process.cwd()` would be surprising and could land
+  data in an arbitrary place. Treat it as "can't resolve → ignore the setting."
+- **Extracted a vscode-free helper `src/core/resolve_storage_dir.ts`.** `paths.ts` imports `vscode`, which the
+  pure-Node test suite can't load. Putting the pure logic in its own module lets it be unit-tested directly,
+  mirroring how `build_info.ts` stays testable.
+
+## Rejected approaches
+
+- Full VS Code variable substitution (`${workspaceFolder}`, `${env:...}`) — out of scope; see above.
+
+## Retrospective
+
+Shipped as planned: a vscode-free `resolve_storage_dir(raw, workspace_root)` helper (absolute → normalized,
+relative → joined onto the first workspace folder, empty/unresolvable → null), wired into `resolve_paths`
+which falls back to VS Code's default global storage on null. `test-workspace/.vscode/settings.json` now
+commits the portable `"global-storage"`. Four unit cases in `src/test/test_paths.ts` cover all modes.
+
+Small deviation from the plan: on code review we renamed the surrounding `customDir`/`globalDir` locals (plus
+the new `resolvedDir`) to snake_case per CLAUDE.md rather than leaving the new var matching the old camelCase.
+Version bumped 0.3.0 → 0.3.1 (patch, bugfix).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "TimeScope",
     "description": "A VS Code extension for tracking work sessions with analytics and a dashboard.",
     "publisher": "davidclass",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "engines": {
         "vscode": "^1.85.0"
     },

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
+import { resolve_storage_dir } from "./resolve_storage_dir";
 
 export interface TimeScopePaths {
     global_jobs_path: string;
@@ -12,24 +13,24 @@ export interface TimeScopePaths {
 export function resolve_paths(context: vscode.ExtensionContext): TimeScopePaths {
     const config = vscode.workspace.getConfiguration("timescope");
 
-    // New folder-based setting
-    const customDir = config.get<string>("global_storage_dir", "").trim();
-
-    // If user picked a folder → use it
-    // Otherwise → use VS Code's global storage folder
-    const globalDir = customDir || context.globalStorageUri.fsPath;
+    // Folder-based setting. A relative value resolves against the first workspace
+    // folder; an absolute value is used as-is. If it can't be resolved (empty, or
+    // relative with no workspace open) → fall back to VS Code's global storage folder.
+    const custom_dir = config.get<string>("global_storage_dir", "");
+    const workspace_folder = vscode.workspace.workspaceFolders?.[0];
+    const resolved_dir = resolve_storage_dir(custom_dir, workspace_folder?.uri.fsPath);
+    const global_dir = resolved_dir ?? context.globalStorageUri.fsPath;
 
     // Ensure folder exists
-    if (!fs.existsSync(globalDir)) {
-        fs.mkdirSync(globalDir, { recursive: true });
+    if (!fs.existsSync(global_dir)) {
+        fs.mkdirSync(global_dir, { recursive: true });
     }
 
     // Canonical filenames inside the chosen folder
-    const global_jobs_path = path.join(globalDir, "jobs.json");
-    const global_log_path  = path.join(globalDir, "logs.jsonl");
+    const global_jobs_path = path.join(global_dir, "jobs.json");
+    const global_log_path  = path.join(global_dir, "logs.jsonl");
 
     // Workspace folder logic unchanged
-    const workspace_folder = vscode.workspace.workspaceFolders?.[0];
     let workspace_jobs_path: string | undefined = undefined;
     let workspace_log_path: string | undefined = undefined;
 

--- a/src/core/resolve_storage_dir.ts
+++ b/src/core/resolve_storage_dir.ts
@@ -1,0 +1,21 @@
+import * as path from "path";
+
+/**
+ * Resolve the effective global storage directory from the raw `timescope.global_storage_dir`
+ * setting value. Kept vscode-free so it can be unit-tested by the pure-Node suite.
+ *
+ * - "" / whitespace         → null (caller uses VS Code's default global storage)
+ * - absolute path           → returned as-is (normalized)
+ * - relative + ws root       → joined against the workspace root
+ * - relative + no ws root    → null (unresolvable → caller falls back to the default)
+ */
+export function resolve_storage_dir(
+    raw_setting: string,
+    workspace_root: string | undefined
+): string | null {
+    const trimmed = raw_setting.trim();
+    if (!trimmed) { return null; }
+    if (path.isAbsolute(trimmed)) { return path.normalize(trimmed); }
+    if (!workspace_root) { return null; }
+    return path.resolve(workspace_root, trimmed);
+}

--- a/src/test/run_tests.ts
+++ b/src/test/run_tests.ts
@@ -8,6 +8,7 @@ import { run_event_tests } from "./test_event";
 import { run_job_domain_tests } from "./test_job";
 import { run_job_collection_tests } from "./test_job_collection";
 import { run_build_info_tests } from "./test_build_info";
+import { run_resolve_storage_dir_tests } from "./test_paths";
 
 async function main() {
     try {
@@ -33,6 +34,7 @@ async function main() {
         run_dashboard_replaceEvent_tests();
         run_dashboard_editRoundTrip_tests();
         run_build_info_tests();
+        run_resolve_storage_dir_tests();
         console.log("All tests passed.");
         process.exit(0);
     } catch (err) {

--- a/src/test/test_paths.ts
+++ b/src/test/test_paths.ts
@@ -1,0 +1,78 @@
+import * as path from "path";
+import * as assert from "assert";
+import { resolve_storage_dir } from "../core/resolve_storage_dir";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// resolve_storage_dir
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Tests resolve_storage_dir absolute-path passthrough:
+ * - Target: resolve_storage_dir in src/core/resolve_storage_dir.ts
+ * - What: an absolute global_storage_dir is returned as-is (normalized),
+ *   independent of the workspace root — preserving today's behavior.
+ * - Does: passes an absolute path with and without a workspace root.
+ * - Why: existing users pin an absolute folder; that must keep working.
+ */
+export function run_resolve_storage_dir_absolute_tests(): void {
+    const abs = path.resolve(path.sep === "\\" ? "C:\\data\\ts" : "/data/ts");
+
+    assert.strictEqual(resolve_storage_dir(abs, "/some/workspace"), path.normalize(abs),
+        "absolute value returned normalized, workspace ignored");
+    assert.strictEqual(resolve_storage_dir(abs, undefined), path.normalize(abs),
+        "absolute value works with no workspace root");
+
+    console.log("  ✓ resolve_storage_dir absolute tests passed");
+}
+
+/**
+ * Tests resolve_storage_dir relative resolution against the workspace root:
+ * - Target: resolve_storage_dir in src/core/resolve_storage_dir.ts
+ * - What: a relative value is joined onto the first workspace folder's root.
+ * - Does: resolves "global-storage" against a workspace root.
+ * - Why: this is the fix — it lets test-workspace commit a portable value
+ *   that resolves correctly on every clone.
+ */
+export function run_resolve_storage_dir_relative_tests(): void {
+    const wsRoot = path.resolve(path.sep === "\\" ? "C:\\clone\\ts\\test-workspace" : "/clone/ts/test-workspace");
+
+    assert.strictEqual(resolve_storage_dir("global-storage", wsRoot),
+        path.resolve(wsRoot, "global-storage"),
+        "relative value joined against workspace root");
+    assert.strictEqual(resolve_storage_dir("./nested/dir", wsRoot),
+        path.resolve(wsRoot, "./nested/dir"),
+        "relative value with ./ resolves against workspace root");
+
+    console.log("  ✓ resolve_storage_dir relative tests passed");
+}
+
+/**
+ * Tests resolve_storage_dir null fallback cases:
+ * - Target: resolve_storage_dir in src/core/resolve_storage_dir.ts
+ * - What: returns null when there's nothing to resolve — so the caller falls
+ *   back to VS Code's default global storage dir.
+ * - Does: empty/whitespace values, and a relative value with no workspace root.
+ * - Why: an unresolvable relative path must never silently land data in cwd;
+ *   null signals the caller to use the safe default.
+ */
+export function run_resolve_storage_dir_fallback_tests(): void {
+    assert.strictEqual(resolve_storage_dir("", "/some/workspace"), null,
+        "empty value → null");
+    assert.strictEqual(resolve_storage_dir("   ", "/some/workspace"), null,
+        "whitespace-only value → null");
+    assert.strictEqual(resolve_storage_dir("global-storage", undefined), null,
+        "relative value with no workspace root → null");
+
+    console.log("  ✓ resolve_storage_dir fallback tests passed");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Exported runner
+// ═══════════════════════════════════════════════════════════════════════════
+
+export function run_resolve_storage_dir_tests(): void {
+    console.log("paths: resolve_storage_dir");
+    run_resolve_storage_dir_absolute_tests();
+    run_resolve_storage_dir_relative_tests();
+    run_resolve_storage_dir_fallback_tests();
+}

--- a/test-workspace/.vscode/settings.json
+++ b/test-workspace/.vscode/settings.json
@@ -2,7 +2,8 @@
     "VsCodeTaskButtons.showCounter": true,
 
     // Pin TimeScope storage for F5 / Extension Development Host sessions so
-    // dev testing NEVER touches real tracking data. paths.ts does not expand
-    // VS Code variables, so this must be an absolute path on this machine.
-    "timescope.global_storage_dir": "r:\\vscode_customizations\\timescope\\test-workspace\\global-storage"
+    // dev testing NEVER touches real tracking data. A relative value resolves
+    // against this workspace folder, so this is portable across clones and
+    // machines (→ test-workspace/global-storage).
+    "timescope.global_storage_dir": "global-storage"
 }


### PR DESCRIPTION
## Summary

`resolve_paths` used the `timescope.global_storage_dir` setting verbatim, so isolating F5 test storage required a machine-specific **absolute** path that broke on any other clone. A **relative** value now resolves against the first workspace folder; absolute values keep working as before.

## User-facing behavior

- `timescope.global_storage_dir` accepts a relative path (resolved against the first workspace folder) or an absolute path (unchanged).
- Empty, or relative with no workspace folder open → falls back to VS Code's default global storage (the setting is safely ignored, never resolved against `cwd`).
- `test-workspace/.vscode/settings.json` now commits the portable value `"global-storage"`, so F5 isolation works on every clone/machine.

## Technical changes

- New vscode-free helper `src/core/resolve_storage_dir.ts` (absolute → normalized, relative + ws root → joined, empty/unresolvable → null). Kept separate from `paths.ts` (which imports `vscode`) so the pure-Node suite can unit-test it, mirroring `build_info.ts`.
- `resolve_paths` calls the helper and falls back to `context.globalStorageUri.fsPath` on null.
- Four unit cases in `src/test/test_paths.ts` covering all resolution modes.
- Version 0.3.0 → 0.3.1 (patch); CHANGELOG line; decision log in `docs/dev-log/issue-33-relative-storage-dir.md`.

```mermaid
flowchart LR
    S["global_storage_dir setting"] --> R{resolve_storage_dir}
    R -->|absolute| A["use as-is (normalized)"]
    R -->|relative + ws folder| J["join onto workspace root"]
    R -->|empty / relative, no ws| N["null"]
    N --> D["fall back to VS Code global storage"]
```

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)