### PR TITLE
Seed a workspace-local fixture to exercise cross-file dedup/merge (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ One line per merged PR, added at PR time under **Unreleased**. At release, entri
 
 ## Unreleased
 
+- `npm run seed-testdata`: also seeds a workspace-local `.timescope/` store (last week of global events re-emitted with identical IDs + a few unique events under a "Local Client" job) so F5 exercises the cross-file dedup/merge path (#39)
 - `timescope.global_storage_dir`: a relative value now resolves against the first workspace folder (absolute values unchanged), so the isolated F5 test-storage setting is portable across clones and machines (#33)
 - Dev logs: each feature branch keeps a short decision log in `docs/dev-log/` (started at plan time, finalized as a retrospective at PR time) — captures the *why* behind a change, not a spec (#36)
 - Build info: `npm run package` writes `out/buildinfo.json`; visible via the new **TimeScope: Show Build Info** command, the status-bar tooltip, and a dashboard footer — plus a per-PR version-bump policy so the Extensions view version reflects real progress (#35)

--- a/docs/dev-log/issue-39-seed-workspace-fixture.md
+++ b/docs/dev-log/issue-39-seed-workspace-fixture.md
@@ -3,7 +3,7 @@
 > Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
 > Keep it short — capture the *why*, not a blow-by-blow. Skip any section that doesn't apply.
 
-**Issue:** https://github.com/Heliman84/timescope/issues/39  ·  **PR:** <link>
+**Issue:** https://github.com/Heliman84/timescope/issues/39  ·  **PR:** https://github.com/Heliman84/timescope/pull/41
 
 ## Problem
 

--- a/docs/dev-log/issue-39-seed-workspace-fixture.md
+++ b/docs/dev-log/issue-39-seed-workspace-fixture.md
@@ -1,0 +1,47 @@
+# Issue #39 — Seed a workspace-local fixture to exercise cross-file dedup/merge
+
+> Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
+> Keep it short — capture the *why*, not a blow-by-blow. Skip any section that doesn't apply.
+
+**Issue:** https://github.com/Heliman84/timescope/issues/39  ·  **PR:** <link>
+
+## Problem
+
+`npm run seed-testdata` only seeded the global store, so F5 never exercised the global+workspace merge
+path (`loadAllEntries` dedup by event ID, and unique workspace jobs/events surfacing in the summary).
+
+## Decisions & trade-offs
+
+- **Workspace log = a subset of global (last week) re-emitted with identical IDs + ~4 unique events.**
+  Duplicating the *same IDs* is what exercises `loadAllEntries` dedup; a subset (not all) keeps the fixture
+  small while still overlapping. If dedup ever regressed, the duplicated week's hours would visibly double.
+- **A workspace-only job "Local Client" carries ~2 of the unique events.** Verifies a both-files job appears
+  in the summary. It works today only because the dashboard derives job identity from the `job_title`
+  *embedded in each event* (`buildPayload` → `ev.job_title`), not from `jobs.json`.
+- **Also write a workspace `jobs.json` (global jobs + "Local Client").** Currently cosmetic —
+  `JobRepository.loadAll()` reads only the global `jobs.json` — but it's the correct fixture shape for the
+  planned local/global filter. The gap (workspace jobs not merged) is noted, not fixed here.
+- **Test-tooling only.** No `src/` or extension-runtime changes, no new deps. Regenerate the global store
+  exactly as before; the workspace store is additive.
+
+## Rejected approaches
+
+- Duplicating *all* global events in the workspace log — larger fixture with no extra coverage over a subset.
+- Fixing `JobRepository.loadAll()` to merge workspace jobs — real behavior change, out of scope for a seed
+  fixture; belongs with the future local/global filter feature.
+
+## Retrospective
+
+Shipped as planned. `scripts/seed_test_data.js` now writes both stores via a shared `write_store(dir, jobs,
+events)` helper and a `push_session` helper (extracted from the old inline closure). The global store is
+byte-identical to before; the workspace store re-emits the last-week subset of global events (same objects →
+identical deterministic IDs) plus 4 unique events, 2 under a workspace-only "Local Client" job.
+
+Verification (no unit test — this is a `scripts/` dev tool over compiled `out/`, like the existing seed
+script): ran `npm run seed-testdata`, then simulated `loadAllEntries` dedup across both files — 118 raw lines
+→ 96 merged unique (92 global + 4 unique), 22 duplicates collapsed, all four jobs incl. "Local Client"
+present once. Matches the acceptance criteria; F5 confirms it visually.
+
+No deviations from the plan. Left as noted-not-fixed: `JobRepository.loadAll()` still reads only the global
+`jobs.json` (workspace jobs surface via event-embedded titles) — a real merge belongs with the future
+local/global filter.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "TimeScope",
     "description": "A VS Code extension for tracking work sessions with analytics and a dashboard.",
     "publisher": "davidclass",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "engines": {
         "vscode": "^1.85.0"
     },

--- a/scripts/seed_test_data.js
+++ b/scripts/seed_test_data.js
@@ -1,6 +1,17 @@
 /**
- * Seed realistic test data into test-workspace/global-storage/ so an F5
- * Extension Development Host has jobs and weeks of sessions to display.
+ * Seed realistic test data into the isolated F5 test-workspace so an Extension
+ * Development Host has jobs and weeks of sessions to display.
+ *
+ * Writes TWO stores:
+ *   - global    → test-workspace/global-storage/{jobs.json,logs.jsonl}
+ *   - workspace → test-workspace/.timescope/{jobs.json,logs.jsonl}
+ *
+ * The workspace log deliberately re-emits the last week of global events with
+ * their EXACT SAME IDs (record IDs are deterministic: f(timestamp, type, job.id)),
+ * plus a few workspace-only events under a "Local Client" job. This exercises
+ * the extension's cross-file merge — loadAllEntries dedupes by event ID, so the
+ * duplicates must collapse (totals unchanged) while the unique events/job surface
+ * once in the summary.
  *
  * Timestamps are generated relative to NOW so the dashboard's presets
  * (Today / This Week / This Month) always have data — static seed files
@@ -10,7 +21,7 @@
  * and the v2 format header are exactly what the extension reads.
  *
  * Usage: npm run seed-testdata   (compiles first, then runs this)
- * Overwrites test-workspace/global-storage/{jobs.json,logs.jsonl} only.
+ * Overwrites {jobs.json,logs.jsonl} in both stores only.
  */
 
 const fs = require("fs");
@@ -19,7 +30,9 @@ const path = require("path");
 const { Job } = require("../out/core/job");
 const { Event } = require("../out/core/event");
 
-const TARGET_DIR = path.resolve(__dirname, "..", "test-workspace", "global-storage");
+const GLOBAL_DIR = path.resolve(__dirname, "..", "test-workspace", "global-storage");
+const WORKSPACE_DIR = path.resolve(__dirname, "..", "test-workspace", ".timescope");
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 function at(dayOffset, hours, minutes) {
     const d = new Date();
@@ -34,6 +47,36 @@ function is_weekend(dayOffset) {
     return d.getDay() === 0 || d.getDay() === 6;
 }
 
+// Build a start[/pause/resume]/stop session into the given events array.
+function push_session(events, job, dayOffset, startH, startM, stopH, stopM, task, withPause) {
+    events.push(Event.create(job, "start", at(dayOffset, startH, startM)));
+    if (withPause) {
+        events.push(Event.create(job, "pause", at(dayOffset, startH + 1, 15)));
+        events.push(Event.create(job, "resume", at(dayOffset, startH + 1, 30)));
+    }
+    events.push(Event.create(job, "stop", at(dayOffset, stopH, stopM), task));
+}
+
+// Write a {jobs.json, logs.jsonl} store, matching the exact on-disk format the
+// extension reads (canonical DTO fields, v2 header, one JSONL event per line).
+function write_store(dir, jobList, events) {
+    fs.mkdirSync(dir, { recursive: true });
+
+    const jobDTOs = jobList.map((j) => ({
+        job_id: j.id,
+        job_title: j.title,
+        created: j.createdAt,
+        job_seed: j.seed,
+    }));
+    fs.writeFileSync(path.join(dir, "jobs.json"), JSON.stringify(jobDTOs, null, 2) + "\n");
+
+    const sorted = events.slice().sort((a, b) => a.timestamp - b.timestamp);
+    const lines = [JSON.stringify({ _format_version: 2 }), ...sorted.map((e) => e.toJSONL())];
+    fs.writeFileSync(path.join(dir, "logs.jsonl"), lines.join("\n") + "\n");
+
+    return { jobs: jobDTOs.length, events: sorted.length };
+}
+
 function main() {
     const jobs = {
         client_a: Job.create({ title: "Client A", created: at(35, 8, 0) }),
@@ -41,45 +84,42 @@ function main() {
         internal: Job.create({ title: "Internal", created: at(28, 8, 0) }),
     };
 
-    const events = [];
-    const session = (job, dayOffset, startH, startM, stopH, stopM, task, withPause) => {
-        events.push(Event.create(job, "start", at(dayOffset, startH, startM)));
-        if (withPause) {
-            events.push(Event.create(job, "pause", at(dayOffset, startH + 1, 15)));
-            events.push(Event.create(job, "resume", at(dayOffset, startH + 1, 30)));
-        }
-        events.push(Event.create(job, "stop", at(dayOffset, stopH, stopM), task));
-    };
-
-    // ~4 weeks of weekday history, newest day = today
+    // ── Global store: ~4 weeks of weekday history, newest day = today ──
+    const globalEvents = [];
     for (let day = 27; day >= 0; day--) {
         if (is_weekend(day)) continue;
-        session(jobs.client_a, day, 9, 0, 11, 30, "design review", day % 2 === 0);
+        push_session(globalEvents, jobs.client_a, day, 9, 0, 11, 30, "design review", day % 2 === 0);
         if (day % 3 !== 0) {
-            session(jobs.client_b, day, 13, 0, 15, 45, "site inspection notes", false);
+            push_session(globalEvents, jobs.client_b, day, 13, 0, 15, 45, "site inspection notes", false);
         }
         if (day % 5 === 0) {
-            session(jobs.internal, day, 16, 0, 17, 0, "invoicing + admin", false);
+            push_session(globalEvents, jobs.internal, day, 16, 0, 17, 0, "invoicing + admin", false);
         }
     }
 
-    events.sort((a, b) => a.timestamp - b.timestamp);
+    const global = write_store(GLOBAL_DIR, Object.values(jobs), globalEvents);
 
-    fs.mkdirSync(TARGET_DIR, { recursive: true });
+    // ── Workspace store: cross-file dedup/merge fixture ──
+    // Duplicates: the last week of global events, re-emitted with identical IDs
+    // (record IDs are deterministic) → loadAllEntries must collapse them.
+    const cutoff = Date.now() - WEEK_MS;
+    const duplicates = globalEvents.filter((e) => e.timestamp >= cutoff);
 
-    const jobDTOs = Object.values(jobs).map((j) => ({
-        job_id: j.id,
-        job_title: j.title,
-        created: j.createdAt,
-        job_seed: j.seed,
-    }));
-    fs.writeFileSync(path.join(TARGET_DIR, "jobs.json"), JSON.stringify(jobDTOs, null, 2) + "\n");
+    // Unique: a workspace-only "Local Client" job + a novel-time Client A session,
+    // none of which exists in the global log (distinct job.id or timestamp → fresh IDs).
+    const localClient = Job.create({ title: "Local Client", created: at(6, 8, 0) });
+    const uniqueEvents = [];
+    push_session(uniqueEvents, localClient, 1, 10, 0, 12, 0, "workspace-only meeting", false);
+    push_session(uniqueEvents, jobs.client_a, 1, 19, 0, 20, 30, "after-hours workspace note", false);
 
-    const lines = [JSON.stringify({ _format_version: 2 }), ...events.map((e) => e.toJSONL())];
-    fs.writeFileSync(path.join(TARGET_DIR, "logs.jsonl"), lines.join("\n") + "\n");
+    const workspaceJobs = [...Object.values(jobs), localClient];
+    const workspaceEvents = [...duplicates, ...uniqueEvents];
+    const workspace = write_store(WORKSPACE_DIR, workspaceJobs, workspaceEvents);
 
-    console.log(`Seeded ${jobDTOs.length} jobs and ${events.length} events into ${TARGET_DIR}`);
-    console.log("Press F5 — the dashboard now has ~4 weeks of sessions.");
+    console.log(`Global    → ${global.jobs} jobs, ${global.events} events  (${GLOBAL_DIR})`);
+    console.log(`Workspace → ${workspace.jobs} jobs, ${workspace.events} events  (${WORKSPACE_DIR})`);
+    console.log(`            ${duplicates.length} duplicate the last week of global (dedup on merge), ${uniqueEvents.length} unique.`);
+    console.log("Press F5 — totals should be unchanged by the duplicates; the 'Local Client' job and the unique sessions appear once.");
 }
 
 main();


### PR DESCRIPTION
## Summary

`npm run seed-testdata` only seeded the **global** store, so an F5 session never exercised the global+workspace merge path. It now also writes a workspace-local store at `test-workspace/.timescope/`, deliberately re-emitting the last week of global events with their exact same (deterministic) IDs plus a few unique workspace-only events — so F5 exercises `loadAllEntries`' cross-file dedup by event ID.

## User-facing behavior (F5 dev tooling)

- One `npm run seed-testdata` writes **both** stores; console reports each.
- **Global** `test-workspace/global-storage/` — byte-identical output to before (3 jobs, ~4 weeks).
- **Workspace** `test-workspace/.timescope/` — the last-week subset of global events re-emitted with identical IDs (duplicates) + 4 unique events, 2 under a new **"Local Client"** job.
- On F5 the merged dashboard collapses the duplicates (totals unchanged) and shows the unique events + "Local Client" job once.

## Technical changes

- Extract `push_session(events, …)` and `write_store(dir, jobs, events)` helpers; global generation unchanged, workspace store additive.
- Unique events can't collide with global IDs (distinct `job.id` or timestamp → fresh deterministic IDs); the extra Client A session (19:00) doesn't overlap the 09:00 one, so merged session state stays legal.
- Verified by simulating `loadAllEntries` across both files: 118 raw lines → **96 merged** (92 global + 4 unique), 22 duplicates collapsed, all four jobs incl. "Local Client" present once.
- Test-tooling only — no `src/` or runtime changes, no new deps. Generated store files are gitignored.
- Version 0.3.1 → 0.3.2 (patch); CHANGELOG line; decision log in `docs/dev-log/issue-39-seed-workspace-fixture.md`.

## Notes

Surfaces (does not fix) that `JobRepository.loadAll()` reads only the global `jobs.json` — workspace jobs currently reach the summary via the job title embedded in each event. A real workspace-jobs merge and a local/global filter are left to future work.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)