### PR TITLE
Summary view: integrated filtering & sorting (#5)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,42 +1,45 @@
 {
-    "permissions": {
-        "allow": [
-            "Bash(npm test)",
-            "Bash(npm run compile)",
-            "Bash(npm run watch)",
-            "Bash(npm run package)",
-            "Bash(npm run vscode:prepublish)",
-            "Bash(npm install)",
-            "Bash(npx tsc:*)",
-            "Bash(npx vsce package:*)",
-            "Bash(git status:*)",
-            "Bash(git diff:*)",
-            "Bash(git log:*)",
-            "Bash(git show:*)",
-            "Bash(git branch)",
-            "Bash(git branch --list:*)",
-            "Bash(git fetch:*)",
-            "Bash(git pull)",
-            "Bash(git add:*)",
-            "Bash(git commit:*)",
-            "Bash(git checkout:*)",
-            "Bash(git push)",
-            "Bash(git push -u origin feature/:*)",
-            "Bash(gh issue view:*)",
-            "Bash(gh issue list:*)",
-            "Bash(gh pr view:*)",
-            "Bash(gh pr list:*)",
-            "Bash(gh pr diff:*)",
-            "Bash(gh pr checks:*)"
-        ],
-        "ask": [
-            "Bash(git push --force:*)",
-            "Bash(git push -f:*)",
-            "Bash(git branch -D:*)",
-            "Bash(git reset --hard:*)",
-            "Bash(gh release create:*)",
-            "Bash(gh pr merge:*)",
-            "Bash(code --install-extension:*)"
-        ]
-    }
+  "permissions": {
+    "allow": [
+      "Bash(npm test)",
+      "Bash(npm run compile)",
+      "Bash(npm run watch)",
+      "Bash(npm run package)",
+      "Bash(npm run vscode:prepublish)",
+      "Bash(npm install)",
+      "Bash(npx tsc:*)",
+      "Bash(npx vsce package:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch)",
+      "Bash(git branch --list:*)",
+      "Bash(git fetch:*)",
+      "Bash(git pull)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git push)",
+      "Bash(git push -u origin feature/:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)"
+    ],
+    "ask": [
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git branch -D:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(gh release create:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(code --install-extension:*)"
+    ]
+  },
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ out/
 /test-output/
 /test-results/
 /playwright-report/
+/.playwright-mcp/
 
 # Node / build artifacts
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ One line per merged PR, added at PR time under **Unreleased**. At release, entri
 
 ## Unreleased
 
+- Summary view redesign: sidebar replaced by integrated filtering — date presets (default Last 14 Days, now actually applied) with native start/end date pickers, a checkbox job legend synced with a table job dropdown, inclusive duration and pause/resume range filters, sortable columns, an explicit empty state, and a validated colorblind-safe chart palette; all filters drive the charts and table together (#5)
 - `npm run seed-testdata`: also seeds a workspace-local `.timescope/` store (last week of global events re-emitted with identical IDs + a few unique events under a "Local Client" job) so F5 exercises the cross-file dedup/merge path (#39)
 - `timescope.global_storage_dir`: a relative value now resolves against the first workspace folder (absolute values unchanged), so the isolated F5 test-storage setting is portable across clones and machines (#33)
 - Dev logs: each feature branch keeps a short decision log in `docs/dev-log/` (started at plan time, finalized as a retrospective at PR time) — captures the *why* behind a change, not a spec (#36)

--- a/docs/dev-log/issue-5-log-filtering.md
+++ b/docs/dev-log/issue-5-log-filtering.md
@@ -45,6 +45,8 @@ The summary view's filter sidebar is weak: the date preset defaults to "Today" b
 - **"Clear Filters" became "Reset filters"**, placed at the right end of the date bar; ghost-button styling.
 - **Chart-click row highlight** restyled from light-yellow (glared on dark) to an accent wash.
 
+- **Code review (8-angle, high effort) findings fixed:** HTML/attribute injection via unescaped job/task names in the new innerHTML surfaces (plus the pre-existing edit-modal case) — fixed with an `escape_html` helper and locked in by a hostile-job-name Playwright test; range inputs debounced 150ms (chart teardown per keystroke); legend/dropdown render + change handlers unified into one parameterized job-picker (two angles flagged sync-drift risk); edit buttons moved to a delegated listener; job list cached per payload; chart chrome tokens now read from the CSS custom properties. Waived (queued for review): day-total label rides the alphabetically-last dataset; webview session math duplicates `core/session.ts` (pre-existing, needs its own issue); fixture/test constants deliberately mirrored across the two test trees.
+
 ## Retrospective
 
 _To be finalized at PR time._

--- a/docs/dev-log/issue-5-log-filtering.md
+++ b/docs/dev-log/issue-5-log-filtering.md
@@ -1,0 +1,50 @@
+# Issue #5 — Introduce Summary View: Log Filtering
+
+> Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
+> Keep it short — capture the *why*, not a blow-by-blow. Skip any section that doesn't apply.
+
+**Issue:** https://github.com/Heliman84/timescope/issues/5  ·  **PR:** _pending_
+
+## Problem
+
+The summary view's filter sidebar is weak: the date preset defaults to "Today" but is never applied on load, job filtering lives in a sidebar disconnected from the charts, and there's no way to filter by explicit dates, duration, or pause/resume count — nor to sort the sessions table. Issue #5 replaces the sidebar with filtering integrated into the main view, driving charts and table from one filtered session set.
+
+## Decisions & trade-offs (scoping, 2026-07-16)
+
+- **One filter state feeds everything.** Date, job, duration, and pause/resume filters all apply to the pie chart, stacked bar, and raw sessions table together. Trade-off: charts no longer show "true totals for the period" when duration/pause filters are active — accepted for consistency.
+- **Date presets:** This Week, Last 7 Days, **Last 14 Days (default, actually applied on load)**, This Month, Last 3 Months, Last Year, All. Preset selection populates the start/end fields; hand-editing either field flips the preset to Custom. First date picked fills both fields (single-day convenience).
+- **Native `<input type="date">`** for the date picker rather than a hand-built inline calendar — nearly free, theme-correct in VS Code, and honors the no-new-dependencies rule.
+- **Job filtering has two synced surfaces:** a scrollable checkbox legend beside the pie chart (large, bold entries; "All" on top; stable colors — filtering hides/recalculates, never re-derives the palette) and a multi-select dropdown in the raw sessions table's filter row. Both views of one shared selection state.
+- **Built-in Chart.js legends removed** on both charts; the custom checkbox legend is the single legend.
+- **Table sorting is in scope** (date, job, duration, pause/resume count columns).
+- **Duration and pause/resume filters** are inclusive "greater than ___ and less than ___" ranges; duration in hours. Bar chart labels stay at one decimal place to minimize clutter.
+- **Don't lock out issue #3:** the filter model treats event source (local/global/merged) as a first-class dimension so #3's scope selector slots in later without rework. Payload already carries per-event `global_line_index` / `workspace_line_index` provenance.
+- **Robust webview test automation is a requirement, not an afterthought** — the Playwright suite in `tests/webview/` grows with every filter behavior (default-applied preset, preset↔field sync, single-day fill, legend/dropdown sync, chart recalculation, sorting).
+- **Layout (wireframe agreed):** date filter is global, in a bar at the top with the reset action; duration/pause/job filters live in the raw-sessions table's filter row (session-level concepts, though they also recalc the charts); build info moves to the top-right of the header; charts stay **vertically stacked**.
+- **Default table sort:** newest-first (Start descending), single-column sort, click header to toggle asc/desc.
+- **Explicit empty state** ("No sessions match the current filters") instead of a silently empty table.
+- **Wide date ranges (Last Year / All) accepted as-is** — the stacked bar may get dense; week/month bucketing is its own future issue.
+- **Sequencing:** filter-state module + tests first (pure logic, TDD), then wire charts/table, then design pass (frontend-design input + screenshot reviews), then F5.
+- **Test infrastructure:** freeze time with Playwright's `page.clock` (kills the documented midnight flake in fixtures), build a filter-focused fixture (~12 jobs, sessions on preset boundaries, duration/pause spread), assert on Chart.js instance data rather than pixels.
+- **Deferred to design time** (with frontend-design input; user dislikes serif fonts): the "Clear Filters" rename ("Reset" / "Reset filters" / "Show all" candidates — action lives in the top date bar).
+
+## Rejected approaches
+
+- Hand-built inline calendar widget — high cost in vanilla JS for little gain over native date inputs.
+- Job filter as sidebar checkboxes (status quo) or a single dropdown-only control — replaced by the synced legend+dropdown pair from the issue discussion.
+- Re-deriving the chart palette on each filter change — causes color churn; instead the legend keeps all jobs with stable colors and filtering recalculates totals only.
+
+
+## Decisions made during implementation (overnight run, 2026-07-17)
+
+- **"Last Year" preset** resolves like Last 3 Months does: first day of the month eleven months back → today (rolling twelve months, not the previous calendar year). Consistent with the existing preset family; flagged for review.
+- **Date fields are populated on load** with the default preset's resolved range. The issue said fields "begin empty", but that predates the agreed "preset fills the fields" behavior — one source of truth won. The single-day rule still applies whenever both fields are empty (e.g. after selecting the "All" preset).
+- **New-column sort starts descending** (biggest/newest first), second click toggles ascending.
+- **Palette**: the old Tableau-10 failed the colorblind/contrast validator on our dark surface; replaced with a validated 10-slot palette (8 reference slots + 2 extensions, all checks pass on `#1e1e1e`). Colours assigned alphabetically by job name so a job keeps its colour across reloads; past 10 jobs the palette wraps.
+- **Chart chrome**: built-in legends off (the checkbox legend serves both charts), recessive gridlines/ticks, 2px surface gaps between pie slices and stacked segments, selective data labels (pie slices under 5% and bar segments under 0.5h are unlabeled — tooltips still carry the values). Fixed a latent bug where a day's total label vanished if the alphabetically-last job had no hours that day.
+- **"Clear Filters" became "Reset filters"**, placed at the right end of the date bar; ghost-button styling.
+- **Chart-click row highlight** restyled from light-yellow (glared on dark) to an accent wash.
+
+## Retrospective
+
+_To be finalized at PR time._

--- a/docs/dev-log/issue-5-log-filtering.md
+++ b/docs/dev-log/issue-5-log-filtering.md
@@ -58,6 +58,14 @@ Verdict: snappy, functions well. Changes agreed and implemented:
 - **Palette**: David dislikes the hues; deliberately deferred — revisit with him before changing (it stays for its accessibility properties meanwhile).
 
 
+## F5 evaluation round 2 (2026-07-17)
+
+- **Range filters commit on Enter or blur** (native `change`), never per keystroke — typing "0.5" no longer transiently filters on "0". Enter also closes the funnel menu. The 150ms debounce from round 1 was replaced by this (strictly better: no timing at all).
+- **Legend hours**: each legend row shows "(N.Nh)" in muted grey; the All row carries the grand total. Totals respect the date/duration/pause filters but ignore the job selection itself — unchecking a job keeps its number visible (it tells you what re-checking brings back) and keeps it consistent with the "hide, don't re-derive" legend philosophy.
+- **"Last 4 Weeks" preset** added between Last 14 Days and This Month (today−27 → today).
+- **Seed generator follow-up paused** at David's request — no issue/branch action until he says otherwise.
+
+
 ## Retrospective
 
 _To be finalized at PR time._

--- a/docs/dev-log/issue-5-log-filtering.md
+++ b/docs/dev-log/issue-5-log-filtering.md
@@ -81,4 +81,12 @@ Evaluating with real data (via `--from-real`) exposed gaps the short synthetic s
 
 ## Retrospective
 
-_To be finalized at PR time._
+Shipped substantially per plan, but the UX kept evolving through three F5 rounds with real feedback — the durable lesson of this branch:
+
+- **What shipped vs. planned**: the pure `filter_state.js` module, one-filter-state-drives-everything, native date inputs, synced legend, sorting, and the frozen-clock test approach all landed as planned. The *filter surface* did not survive contact with use: the planned table filter row became Excel-style column funnels (sort hint + funnel menu per column), range filters gained commit-on-Enter (replacing a debounce), and per-column Clear buttons appeared — none of which were in the original plan.
+- **The default preset moved twice** (Today → Last 14 Days → Last 4 Weeks) — the right value only became obvious against real data with real gaps.
+- **Real data was the best reviewer.** `--from-real` exposed legend truncation, the buried empty-state, and the narrow-panel column squeeze within minutes of use — after the synthetic seed had hidden all three. The seed generator now mirrors the real store's measured profile so this class of blindness doesn't recur.
+- **Palette**: replaced Tableau-10 with a colorblind/contrast-validated set; David dislikes the hues — revisit is #44, constraint intact.
+- **Code review paid rent**: HTML/attribute injection via job names (real XSS surface in a webview), plus the latent day-total label bug — both fixed and regression-tested.
+- **Spawned issues**: #42 (log hygiene/sanitizer/compaction), #43 (append-only amend events, kills the line-index plumbing), #44 (design pass), #45 (scale smoke test).
+- Final state: 39 Playwright tests + the Node suite (presets incl. DST boundaries, inclusive ranges, sync, palette stability, injection, chart data, real click-through highlighting), v0.4.0.

--- a/docs/dev-log/issue-5-log-filtering.md
+++ b/docs/dev-log/issue-5-log-filtering.md
@@ -3,7 +3,7 @@
 > Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
 > Keep it short — capture the *why*, not a blow-by-blow. Skip any section that doesn't apply.
 
-**Issue:** https://github.com/Heliman84/timescope/issues/5  ·  **PR:** _pending_
+**Issue:** https://github.com/Heliman84/timescope/issues/5  ·  **PR:** https://github.com/Heliman84/timescope/pull/46
 
 ## Problem
 

--- a/docs/dev-log/issue-5-log-filtering.md
+++ b/docs/dev-log/issue-5-log-filtering.md
@@ -47,6 +47,17 @@ The summary view's filter sidebar is weak: the date preset defaults to "Today" b
 
 - **Code review (8-angle, high effort) findings fixed:** HTML/attribute injection via unescaped job/task names in the new innerHTML surfaces (plus the pre-existing edit-modal case) — fixed with an `escape_html` helper and locked in by a hostile-job-name Playwright test; range inputs debounced 150ms (chart teardown per keystroke); legend/dropdown render + change handlers unified into one parameterized job-picker (two angles flagged sync-drift risk); edit buttons moved to a delegated listener; job list cached per payload; chart chrome tokens now read from the CSS custom properties. Waived (queued for review): day-total label rides the alphabetically-last dataset; webview session math duplicates `core/session.ts` (pre-existing, needs its own issue); fixture/test constants deliberately mirrored across the two test trees.
 
+## F5 evaluation round 1 (2026-07-17)
+
+Verdict: snappy, functions well. Changes agreed and implemented:
+
+- **Column-header filter UX (Option 1, Excel/AG-Grid style)** chosen over a Sheets-style header menu — keeps sort one-click. Each sortable header shows a dimmed ↕ hint (accent ▲/▼ when active); Job/Duration/Pause-Resume get a funnel opening a per-column menu (job checkboxes, min/max ranges). Funnel renders in accent when its filter limits data. The separate filter row above the table was removed; global date bar and legend unchanged. One menu open at a time; click-outside and Escape close.
+- **Edit modal keyboard**: Enter = Save, Escape = Cancel.
+- **"Raw Sessions" → "Session Log"** (picked over Sessions / Work Log / Session History).
+- **Seed generator**: history extended to ~6 months (sparser with age) so wide presets have data; new `--from-real [dir]` mode copies the real global store into the isolated test storage (source untouched, workspace store cleared).
+- **Palette**: David dislikes the hues; deliberately deferred — revisit with him before changing (it stays for its accessibility properties meanwhile).
+
+
 ## Retrospective
 
 _To be finalized at PR time._

--- a/docs/dev-log/issue-5-log-filtering.md
+++ b/docs/dev-log/issue-5-log-filtering.md
@@ -68,6 +68,17 @@ Verdict: snappy, functions well. Changes agreed and implemented:
 - **`--from-real` honors `timescope.global_storage_dir`**: the script now reads the VS Code user settings.json and uses the configured storage folder (falls back to default globalStorage; relative values error with instructions to pass the folder explicitly).
 
 
+## F5 evaluation round 3 — real-data findings (2026-07-17)
+
+Evaluating with real data (via `--from-real`) exposed gaps the short synthetic seed had hidden:
+
+- **Default preset → Last 4 Weeks** (was Last 14 Days) — real usage has multi-week gaps, and a two-week default opened to an empty view.
+- **Prominent no-data message in place of the pie chart** ("No data in the selected date range or filters", with a hint that the range may be too narrow) — the old table-only note was too easy to miss.
+- **Legend widened 220→300px** and every name carries a tooltip with the full title — real job titles are hierarchical and long (avg 27 chars, e.g. "Project - Subsystem - Discipline") and truncated badly.
+- **Narrow-panel layout**: below 900px the Duration and Pause/Resume headers abbreviate to "Dur." / "P/R" (dual spans toggled by media query), freeing width for Job and Task.
+- **Seed realism** (measured against the real store): job titles now hierarchical 12–33 chars (real 11–35, avg 27 vs seed 26.6); tasks are generated free text, median 58 / max 372 chars (real 44 / 433) with rare terse and rare very-long entries; pauses on ~half of sessions. Previously: 8-char titles and four fixed short strings — which is exactly why the truncation bug went unseen.
+
+
 ## Retrospective
 
 _To be finalized at PR time._

--- a/docs/dev-log/issue-5-log-filtering.md
+++ b/docs/dev-log/issue-5-log-filtering.md
@@ -64,6 +64,8 @@ Verdict: snappy, functions well. Changes agreed and implemented:
 - **Legend hours**: each legend row shows "(N.Nh)" in muted grey; the All row carries the grand total. Totals respect the date/duration/pause filters but ignore the job selection itself — unchecking a job keeps its number visible (it tells you what re-checking brings back) and keeps it consistent with the "hide, don't re-derive" legend philosophy.
 - **"Last 4 Weeks" preset** added between Last 14 Days and This Month (today−27 → today).
 - **Seed generator follow-up paused** at David's request — no issue/branch action until he says otherwise.
+- **Per-column "Clear" buttons** added to each funnel menu ("Clear" over "Reset": more universal, and distinct from the global "Reset filters" — Clear = this column, Reset = everything). Clearing one column leaves the others intact and closes the menu.
+- **`--from-real` honors `timescope.global_storage_dir`**: the script now reads the VS Code user settings.json and uses the configured storage folder (falls back to default globalStorage; relative values error with instructions to pass the folder explicitly).
 
 
 ## Retrospective

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -378,6 +378,7 @@ sequenceDiagram
 ```
 
 - `dashboard_utils.ts` exports two pure functions: `buildPayload()` (timestamp-descending DTO array) and `filterRelevantErrors()` (scopes validation errors to the edited events).
+- `filter_state.js` (webview) holds the pure filter/sort logic behind the summary view: one filter-state object (date range, jobs, duration/pause ranges, source, sort) that `dashboard.js` renders from. Date presets resolve into explicit `start_day`/`end_day` bounds; `source` (merged/global/workspace) is wired through the filter model as the seam for issue #3, with no UI yet. Loaded as a plain `<script>` in the webview and `require()`d directly by the pure-Node test suite (`src/test/test_filter_state.ts`).
 - `build_info.ts` exports `load_build_info()` (reads `out/buildinfo.json`, `null` if missing/malformed) and formatters `format_status_bar_suffix()` / `format_build_info_full()` (the latter composed from the former). `Runtime` loads it once at construction; the status-bar tooltip, dashboard footer, and the Show Build Info command all render it, with a "no build info" fallback.
 - The controller routes all data access through `Runtime` — never directly to `EventRepository`.
 - `edit_log_entries` (batch edit) follows the same pattern per-edit, with per-item error accumulation.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "TimeScope",
     "description": "A VS Code extension for tracking work sessions with analytics and a dashboard.",
     "publisher": "davidclass",
-    "version": "0.3.2",
+    "version": "0.4.0",
     "engines": {
         "vscode": "^1.85.0"
     },

--- a/scripts/seed_test_data.js
+++ b/scripts/seed_test_data.js
@@ -8,7 +8,7 @@
  *
  * The workspace log deliberately re-emits the last week of global events with
  * their EXACT SAME IDs (record IDs are deterministic: f(timestamp, type, job.id)),
- * plus a few workspace-only events under a "Local Client" job. This exercises
+ * plus a few workspace-only events under a "Meridian" job. This exercises
  * the extension's cross-file merge — loadAllEntries dedupes by event ID, so the
  * duplicates must collapse (totals unchanged) while the unique events/job surface
  * once in the summary.
@@ -64,6 +64,43 @@ function push_session(events, job, dayOffset, startH, startM, stopH, stopM, task
         events.push(Event.create(job, "resume", at(dayOffset, startH + 1, 30)));
     }
     events.push(Event.create(job, "stop", at(dayOffset, stopH, stopM), task));
+}
+
+// ---------------------------------------------------------------------------
+// Task text generator, tuned to the real store's profile: free text, median
+// ~45 chars / avg ~55, almost every task distinct, occasional very long notes
+// (real data maxes out around 430 chars).
+// ---------------------------------------------------------------------------
+
+const TASK_ACTIONS = [
+    "review", "revise", "detail out", "model", "simulate", "document",
+    "debug", "measure and log", "assemble notes on", "follow up on",
+];
+const TASK_SUBJECTS = [
+    "gearbox housing tolerances", "sensor board layout rev C", "test fixture base plate",
+    "supplier drawings package", "BOM and sourcing options", "motor mount interface",
+    "wiring harness routing", "firmware flash sequence", "client feedback items",
+    "acceptance test procedure", "thermal sim boundary conditions", "cable strain relief",
+];
+const TASK_TAILS = [
+    "", "", "", " and send summary to client", " before Thursday design review",
+    " — still waiting on vendor response", " per last week's meeting notes",
+    " and push updates to the shared drive", " (second pass)",
+];
+const TASK_LONG_NOTE =
+    " Longer working notes: walked the whole assembly sequence with the shop, flagged two" +
+    " interference issues near the rear bracket, agreed on a revised tolerance stack for the" +
+    " mating flange, and captured open questions for the supplier call — needs a follow-up" +
+    " session to close out the drawing changes.";
+
+function make_task(seed) {
+    const action = TASK_ACTIONS[seed % TASK_ACTIONS.length];
+    const subject = TASK_SUBJECTS[(seed * 7 + 3) % TASK_SUBJECTS.length];
+    const tail = TASK_TAILS[(seed * 13 + 5) % TASK_TAILS.length];
+    let task = `${action} ${subject}${tail}`;
+    if (seed % 17 === 0) task += TASK_LONG_NOTE; // rare very-long note
+    if (seed % 23 === 0) task = "admin"; // rare terse entry (real min is 4 chars)
+    return task;
 }
 
 // Write a {jobs.json, logs.jsonl} store, matching the exact on-disk format the
@@ -155,22 +192,30 @@ function main() {
         return;
     }
 
+    // Titles mirror the real store's shape: hierarchical "Project - Subsystem -
+    // Discipline" names, 12–33 chars (real profile: 11–35, avg 27).
     const jobs = {
-        client_a: Job.create({ title: "Client A", created: at(190, 8, 0) }),
-        client_b: Job.create({ title: "Client B", created: at(170, 8, 0) }),
-        internal: Job.create({ title: "Internal", created: at(160, 8, 0) }),
+        gearbox: Job.create({ title: "Northwind - Gearbox - MechCAD", created: at(190, 8, 0) }),
+        controls: Job.create({ title: "Northwind - Controls - EE CAD", created: at(170, 8, 0) }),
+        fixture: Job.create({ title: "Halcyon - Fixture - Design Review", created: at(160, 8, 0) }),
+        firmware: Job.create({ title: "Halcyon - Sensor Bd - Firmware", created: at(150, 8, 0) }),
+        internal: Job.create({ title: "Internal R&D", created: at(140, 8, 0) }),
     };
 
     // ── Global store: ~4 weeks of dense weekday history, newest day = today ──
+    // Pauses on ~60% of sessions (real profile: ~0.9 pauses per session).
     const globalEvents = [];
     for (let day = 27; day >= 0; day--) {
         if (is_weekend(day)) continue;
-        push_session(globalEvents, jobs.client_a, day, 9, 0, 11, 30, "design review", day % 2 === 0);
+        push_session(globalEvents, jobs.gearbox, day, 9, 0, 11, 30, make_task(day * 3 + 1), day % 5 !== 0);
         if (day % 3 !== 0) {
-            push_session(globalEvents, jobs.client_b, day, 13, 0, 15, 45, "site inspection notes", false);
+            push_session(globalEvents, jobs.controls, day, 13, 0, 15, 45, make_task(day * 3 + 2), day % 2 === 0);
+        }
+        if (day % 2 === 0) {
+            push_session(globalEvents, jobs.firmware, day, 16, 0, 17, 30, make_task(day * 3 + 3), false);
         }
         if (day % 5 === 0) {
-            push_session(globalEvents, jobs.internal, day, 16, 0, 17, 0, "invoicing + admin", false);
+            push_session(globalEvents, jobs.internal, day, 8, 0, 8, 45, "invoicing + admin", false);
         }
     }
 
@@ -179,10 +224,10 @@ function main() {
     for (let day = 180; day > 27; day--) {
         if (is_weekend(day)) continue;
         if (day % 4 === 0) {
-            push_session(globalEvents, jobs.client_a, day, 9, 30, 12, 0, "archived design work", day % 8 === 0);
+            push_session(globalEvents, jobs.gearbox, day, 9, 30, 12, 0, make_task(day * 5 + 1), day % 8 === 0);
         }
         if (day % 6 === 0) {
-            push_session(globalEvents, jobs.client_b, day, 14, 0, 16, 30, "archived site visit", false);
+            push_session(globalEvents, jobs.fixture, day, 14, 0, 16, 30, make_task(day * 5 + 2), day % 12 === 0);
         }
         if (day % 20 === 0) {
             push_session(globalEvents, jobs.internal, day, 8, 0, 9, 0, "monthly bookkeeping", false);
@@ -197,12 +242,12 @@ function main() {
     const cutoff = Date.now() - WEEK_MS;
     const duplicates = globalEvents.filter((e) => e.timestamp >= cutoff);
 
-    // Unique: a workspace-only "Local Client" job + a novel-time Client A session,
+    // Unique: a workspace-only "Meridian" job + a novel-time Northwind session,
     // none of which exists in the global log (distinct job.id or timestamp → fresh IDs).
-    const localClient = Job.create({ title: "Local Client", created: at(6, 8, 0) });
+    const localClient = Job.create({ title: "Meridian - Onsite Commissioning", created: at(6, 8, 0) });
     const uniqueEvents = [];
-    push_session(uniqueEvents, localClient, 1, 10, 0, 12, 0, "workspace-only meeting", false);
-    push_session(uniqueEvents, jobs.client_a, 1, 19, 0, 20, 30, "after-hours workspace note", false);
+    push_session(uniqueEvents, localClient, 1, 10, 0, 12, 0, "walkthrough with site electrician, punch list captured", false);
+    push_session(uniqueEvents, jobs.gearbox, 1, 19, 0, 20, 30, "after-hours notes on the rear bracket interference fix", false);
 
     const workspaceJobs = [...Object.values(jobs), localClient];
     const workspaceEvents = [...duplicates, ...uniqueEvents];
@@ -211,7 +256,7 @@ function main() {
     console.log(`Global    → ${global.jobs} jobs, ${global.events} events  (${GLOBAL_DIR})`);
     console.log(`Workspace → ${workspace.jobs} jobs, ${workspace.events} events  (${WORKSPACE_DIR})`);
     console.log(`            ${duplicates.length} duplicate the last week of global (dedup on merge), ${uniqueEvents.length} unique.`);
-    console.log("Press F5 — totals should be unchanged by the duplicates; the 'Local Client' job and the unique sessions appear once.");
+    console.log("Press F5 — totals should be unchanged by the duplicates; the 'Meridian' job and the unique sessions appear once.");
 }
 
 main();

--- a/scripts/seed_test_data.js
+++ b/scripts/seed_test_data.js
@@ -114,8 +114,35 @@ function seed_from_real(realDir) {
     console.log("Press F5 — the dashboard shows your real tracking data in the isolated test storage.");
 }
 
+/**
+ * Where the user's real global store lives: the timescope.global_storage_dir
+ * setting when configured (read from the VS Code user settings.json), else
+ * the extension's default globalStorage folder.
+ */
 function default_real_dir() {
     const appdata = process.env.APPDATA || path.join(require("os").homedir(), "AppData", "Roaming");
+
+    const settingsPath = path.join(appdata, "Code", "User", "settings.json");
+    try {
+        const raw = fs.readFileSync(settingsPath, "utf8");
+        // settings.json is JSONC; pull just the one key rather than parsing it all
+        const m = raw.match(/"timescope\.global_storage_dir"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+        if (m) {
+            const configured = JSON.parse(`"${m[1]}"`);
+            if (configured.trim()) {
+                if (!path.isAbsolute(configured)) {
+                    console.error(`--from-real: timescope.global_storage_dir is relative ("${configured}") — it resolves against a workspace folder at runtime, which this script can't know.`);
+                    console.error("Pass the folder explicitly: npm run seed-testdata -- --from-real <dir>");
+                    process.exit(1);
+                }
+                console.log(`--from-real: using configured timescope.global_storage_dir`);
+                return configured;
+            }
+        }
+    } catch {
+        // no readable settings file → fall through to the default location
+    }
+
     return path.join(appdata, "Code", "User", "globalStorage", "davidclass.timescope");
 }
 

--- a/scripts/seed_test_data.js
+++ b/scripts/seed_test_data.js
@@ -20,8 +20,17 @@
  * Uses the compiled domain classes (out/core) so record IDs, field order,
  * and the v2 format header are exactly what the extension reads.
  *
- * Usage: npm run seed-testdata   (compiles first, then runs this)
- * Overwrites {jobs.json,logs.jsonl} in both stores only.
+ * Usage:
+ *   npm run seed-testdata                        synthetic data (~6 months of history)
+ *   npm run seed-testdata -- --from-real         copy YOUR real global store instead
+ *   npm run seed-testdata -- --from-real <dir>   ...from an explicit storage dir
+ *
+ * --from-real COPIES {jobs.json,logs.jsonl} from the real global storage into
+ * the isolated test-workspace global store (the originals are never touched)
+ * and writes an empty workspace store, so F5 shows exactly your real data.
+ * Default real-storage location: %APPDATA%/Code/User/globalStorage/davidclass.timescope
+ *
+ * Overwrites {jobs.json,logs.jsonl} in the two test-workspace stores only.
  */
 
 const fs = require("fs");
@@ -77,14 +86,55 @@ function write_store(dir, jobList, events) {
     return { jobs: jobDTOs.length, events: sorted.length };
 }
 
+// --from-real: copy the user's actual global store into the isolated
+// test-workspace global store (read-only on the source), and clear the
+// workspace store so the dashboard shows exactly the real data.
+function seed_from_real(realDir) {
+    const jobsSrc = path.join(realDir, "jobs.json");
+    const logsSrc = path.join(realDir, "logs.jsonl");
+    if (!fs.existsSync(jobsSrc) || !fs.existsSync(logsSrc)) {
+        console.error(`--from-real: could not find jobs.json + logs.jsonl in:\n  ${realDir}`);
+        console.error("Pass the storage folder explicitly: npm run seed-testdata -- --from-real <dir>");
+        process.exit(1);
+    }
+
+    fs.mkdirSync(GLOBAL_DIR, { recursive: true });
+    fs.copyFileSync(jobsSrc, path.join(GLOBAL_DIR, "jobs.json"));
+    fs.copyFileSync(logsSrc, path.join(GLOBAL_DIR, "logs.jsonl"));
+
+    // Empty workspace store: v2 header only, no jobs
+    fs.mkdirSync(WORKSPACE_DIR, { recursive: true });
+    fs.writeFileSync(path.join(WORKSPACE_DIR, "jobs.json"), "[]\n");
+    fs.writeFileSync(path.join(WORKSPACE_DIR, "logs.jsonl"), JSON.stringify({ _format_version: 2 }) + "\n");
+
+    const lineCount = fs.readFileSync(logsSrc, "utf8").trim().split("\n").length - 1;
+    console.log(`Copied REAL data → ${GLOBAL_DIR}`);
+    console.log(`  source: ${realDir} (untouched)`);
+    console.log(`  ~${lineCount} events; workspace store cleared.`);
+    console.log("Press F5 — the dashboard shows your real tracking data in the isolated test storage.");
+}
+
+function default_real_dir() {
+    const appdata = process.env.APPDATA || path.join(require("os").homedir(), "AppData", "Roaming");
+    return path.join(appdata, "Code", "User", "globalStorage", "davidclass.timescope");
+}
+
 function main() {
+    const args = process.argv.slice(2);
+    const fromRealIdx = args.indexOf("--from-real");
+    if (fromRealIdx !== -1) {
+        const explicit = args[fromRealIdx + 1];
+        seed_from_real(explicit ? path.resolve(explicit) : default_real_dir());
+        return;
+    }
+
     const jobs = {
-        client_a: Job.create({ title: "Client A", created: at(35, 8, 0) }),
-        client_b: Job.create({ title: "Client B", created: at(30, 8, 0) }),
-        internal: Job.create({ title: "Internal", created: at(28, 8, 0) }),
+        client_a: Job.create({ title: "Client A", created: at(190, 8, 0) }),
+        client_b: Job.create({ title: "Client B", created: at(170, 8, 0) }),
+        internal: Job.create({ title: "Internal", created: at(160, 8, 0) }),
     };
 
-    // ── Global store: ~4 weeks of weekday history, newest day = today ──
+    // ── Global store: ~4 weeks of dense weekday history, newest day = today ──
     const globalEvents = [];
     for (let day = 27; day >= 0; day--) {
         if (is_weekend(day)) continue;
@@ -94,6 +144,21 @@ function main() {
         }
         if (day % 5 === 0) {
             push_session(globalEvents, jobs.internal, day, 16, 0, 17, 0, "invoicing + admin", false);
+        }
+    }
+
+    // ── Older history: sparser sessions back to ~6 months so the wide presets
+    //    (Last 3 Months / Last Year) and old-date filtering have real data ──
+    for (let day = 180; day > 27; day--) {
+        if (is_weekend(day)) continue;
+        if (day % 4 === 0) {
+            push_session(globalEvents, jobs.client_a, day, 9, 30, 12, 0, "archived design work", day % 8 === 0);
+        }
+        if (day % 6 === 0) {
+            push_session(globalEvents, jobs.client_b, day, 14, 0, 16, 30, "archived site visit", false);
+        }
+        if (day % 20 === 0) {
+            push_session(globalEvents, jobs.internal, day, 8, 0, 9, 0, "monthly bookkeeping", false);
         }
     }
 

--- a/src/dashboard/controller/dashboard.ts
+++ b/src/dashboard/controller/dashboard.ts
@@ -31,6 +31,9 @@ export async function handle_dashboard(runtime: Runtime, context: vscode.Extensi
     const js_uri = panel.webview.asWebviewUri(
         vscode.Uri.joinPath(context.extensionUri, "out", "dashboard", "webview", "dashboard.js")
     );
+    const filter_state_uri = panel.webview.asWebviewUri(
+        vscode.Uri.joinPath(context.extensionUri, "out", "dashboard", "webview", "filter_state.js")
+    );
     const css_uri = panel.webview.asWebviewUri(
         vscode.Uri.joinPath(context.extensionUri, "out", "dashboard", "webview", "dashboard.css")
     );
@@ -38,6 +41,7 @@ export async function handle_dashboard(runtime: Runtime, context: vscode.Extensi
     html = html
         .replace(/\${nonce}/g, nonce)
         .replace(/\${jsUri}/g, js_uri.toString())
+        .replace(/\${filterStateUri}/g, filter_state_uri.toString())
         .replace(/\${cssUri}/g, css_uri.toString())
         .replace(/\${cspSource}/g, panel.webview.cspSource);
 

--- a/src/dashboard/webview/dashboard.css
+++ b/src/dashboard/webview/dashboard.css
@@ -125,7 +125,7 @@ h2, h3 {
 }
 
 .job-legend {
-    flex: 0 0 220px;
+    flex: 0 0 300px;
     max-height: 350px;
     overflow-y: auto;
     border: 1px solid var(--hairline);
@@ -182,6 +182,29 @@ h2, h3 {
     flex: 1 1 auto;
     min-width: 0;
     max-height: 350px;
+}
+
+/* Prominent no-data message shown in place of the pie chart */
+.pie-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-height: 220px;
+    border: 1px dashed var(--hairline);
+    border-radius: 8px;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--ink-primary);
+    text-align: center;
+    padding: 16px;
+}
+
+.pie-empty-hint {
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--ink-muted);
 }
 
 /* ---------- Column filter menus (funnel in the header) ---------- */
@@ -378,6 +401,34 @@ h2, h3 {
     padding: 24px;
     text-align: center;
     color: var(--ink-muted);
+}
+
+/* ---------- Narrow layout ---------- */
+
+/* Wide layout: full column titles */
+.th-short {
+    display: none;
+}
+
+/* Narrow panel: abbreviate Duration and Pause/Resume so Job and Task
+   get the freed width */
+@media (max-width: 900px) {
+    .th-full {
+        display: none;
+    }
+
+    .th-short {
+        display: inline;
+    }
+
+    #session_table th,
+    #session_table td {
+        padding: 6px 6px;
+    }
+
+    .job-legend {
+        flex: 0 0 240px;
+    }
 }
 
 /* Highlighted session row when clicking a bar segment: accent wash instead

--- a/src/dashboard/webview/dashboard.css
+++ b/src/dashboard/webview/dashboard.css
@@ -405,14 +405,14 @@ h2, h3 {
 
 /* ---------- Narrow layout ---------- */
 
-/* Wide layout: full column titles */
+/* Wide layout: full column titles (Pause/Resume is always "P/R" + tooltip) */
 .th-short {
     display: none;
 }
 
-/* Narrow panel: abbreviate Duration and Pause/Resume so Job and Task
-   get the freed width */
-@media (max-width: 900px) {
+/* Abbreviate Duration well before the table gets cramped — a half-screen
+   panel on a large monitor should already get the short form */
+@media (max-width: 1200px) {
     .th-full {
         display: none;
     }
@@ -420,7 +420,10 @@ h2, h3 {
     .th-short {
         display: inline;
     }
+}
 
+/* Genuinely narrow panel: tighten cells, shrink the legend */
+@media (max-width: 900px) {
     #session_table th,
     #session_table td {
         padding: 6px 6px;

--- a/src/dashboard/webview/dashboard.css
+++ b/src/dashboard/webview/dashboard.css
@@ -1,59 +1,114 @@
 
+/* Chrome & ink tokens (dark surface). Chart-side copies of the ink/surface
+   values live in dashboard.js as CHART_* constants — keep them in sync. */
+:root {
+    --surface: #1e1e1e;
+    --surface-raised: #242424;
+    --ink-primary: #ffffff;
+    --ink-secondary: #c3c2b7;
+    --ink-muted: #898781;
+    --hairline: rgba(255, 255, 255, 0.10);
+    --gridline: #2c2c2a;
+    --accent: #3987e5;
+    --accent-wash: rgba(57, 135, 229, 0.16);
+}
+
 body {
     margin: 0;
     padding: 0;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    color: var(--ink-secondary);
+    background: var(--surface);
+}
+
+h2, h3 {
+    color: var(--ink-primary);
+    font-weight: 600;
+}
+
+/* ---------- Header ---------- */
+
+#dashboard_header {
     display: flex;
-    font-family: sans-serif;
-    height: 100vh;
-    overflow: hidden;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--hairline);
 }
 
-#sidebar {
-    width: 260px;
-    background: #1e1e1e;
-    color: #ddd;
-    padding: 16px;
-    overflow-y: auto;
-    border-right: 1px solid #333;
+#dashboard_header h2 {
+    margin: 0;
 }
 
-.sidebar-button {
-    width: 100%;
-    padding: 8px 12px;
-    margin-top: 12px;
-    background: #444;
-    color: #fff;
-    border: 1px solid #666;
+.build-info {
+    color: var(--ink-muted);
+    font-size: 11px;
+    white-space: nowrap;
+}
+
+/* ---------- Date bar ---------- */
+
+#date_bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 16px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--hairline);
+    background: var(--surface-raised);
+}
+
+.date-field,
+.filter-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+}
+
+.date-field label,
+.filter-field label {
+    color: var(--ink-muted);
+}
+
+#date_bar select,
+#date_bar input,
+#session_filter_row input {
+    background: var(--surface);
+    color: var(--ink-primary);
+    border: 1px solid var(--hairline);
+    border-radius: 4px;
+    padding: 4px 6px;
+    font-family: inherit;
+    color-scheme: dark;
+}
+
+.reset-button {
+    padding: 6px 14px;
+    background: transparent;
+    color: var(--ink-secondary);
+    border: 1px solid var(--hairline);
     border-radius: 4px;
     cursor: pointer;
-    text-align: left;
+    font-family: inherit;
+    margin-left: auto;
 }
 
-.sidebar-button:hover {
-    background: #555;
+.reset-button:hover {
+    background: var(--accent-wash);
+    color: var(--ink-primary);
+    border-color: var(--accent);
 }
 
-.build-info-footer {
-    margin-top: 16px;
-    padding-top: 12px;
-    border-top: 1px solid #333;
-    color: #888;
-    font-size: 11px;
-}
+/* ---------- Main ---------- */
 
 #main {
-    flex: 1;
     padding: 16px;
-    overflow-y: auto;
-}
-
-.section {
-    margin-bottom: 24px;
 }
 
 .chart-container {
     margin-bottom: 40px;
-    max-height: 400px;
 }
 
 #pie_chart,
@@ -61,25 +116,287 @@ body {
     max-height: 350px;
 }
 
+/* ---------- Pie section: legend + canvas ---------- */
+
+.pie-layout {
+    display: flex;
+    gap: 24px;
+    align-items: flex-start;
+}
+
+.job-legend {
+    flex: 0 0 220px;
+    max-height: 350px;
+    overflow-y: auto;
+    border: 1px solid var(--hairline);
+    border-radius: 6px;
+    padding: 8px;
+    background: var(--surface-raised);
+}
+
+.legend-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--ink-primary);
+}
+
+.legend-row:hover {
+    background: var(--accent-wash);
+}
+
+.legend-swatch {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    flex: 0 0 auto;
+    border: 1px solid var(--hairline);
+}
+
+.legend-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.legend-all {
+    border-bottom: 1px solid var(--hairline);
+    margin-bottom: 4px;
+    padding-bottom: 8px;
+    border-radius: 4px 4px 0 0;
+}
+
+.pie-canvas-wrap {
+    flex: 1 1 auto;
+    min-width: 0;
+    max-height: 350px;
+}
+
+/* ---------- Session filter row ---------- */
+
+#session_filter_row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 20px;
+    margin-bottom: 12px;
+}
+
+.filter-field {
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+}
+
+.filter-field input[type="number"] {
+    width: 64px;
+}
+
+.range-sep {
+    color: var(--ink-muted);
+}
+
+/* Job dropdown (native <details>) */
+
+.job-dropdown {
+    position: relative;
+}
+
+.job-dropdown summary {
+    list-style: none;
+    cursor: pointer;
+    background: var(--surface);
+    color: var(--ink-primary);
+    border: 1px solid var(--hairline);
+    border-radius: 4px;
+    padding: 4px 24px 4px 8px;
+    min-width: 100px;
+}
+
+.job-dropdown summary::-webkit-details-marker {
+    display: none;
+}
+
+.job-dropdown summary::after {
+    content: "▾";
+    position: absolute;
+    right: 8px;
+    color: var(--ink-muted);
+}
+
+.job-dropdown-list {
+    position: absolute;
+    z-index: 10;
+    margin-top: 4px;
+    max-height: 260px;
+    overflow-y: auto;
+    background: var(--surface-raised);
+    border: 1px solid var(--hairline);
+    border-radius: 4px;
+    padding: 6px;
+    min-width: 160px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.dropdown-row {
+    display: block;
+    padding: 3px 4px;
+    cursor: pointer;
+    white-space: nowrap;
+    border-radius: 3px;
+}
+
+.dropdown-row:hover {
+    background: var(--accent-wash);
+}
+
+/* ---------- Session table ---------- */
+
 #session_table {
     width: 100%;
     border-collapse: collapse;
 }
 
-#session_table th, #session_table td {
-    border: 1px solid #444;
-    padding: 6px 8px;
+#session_table th,
+#session_table td {
+    border-bottom: 1px solid var(--hairline);
+    padding: 6px 10px;
+    text-align: left;
 }
 
-/* Highlighted session row when filtering by chart click */
-.session-highlighted td {
-    background: #fff3bf; /* light yellow */
-    color: #000; /* dark text for contrast */
+#session_table th {
+    color: var(--ink-muted);
+    font-size: 12px;
     font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    border-bottom: 1px solid var(--gridline);
+}
+
+#session_table td {
+    font-variant-numeric: tabular-nums;
+}
+
+#session_table tbody tr:hover {
+    background: rgba(255, 255, 255, 0.03);
+}
+
+#session_table th.sortable {
+    cursor: pointer;
+    user-select: none;
+}
+
+#session_table th.sortable:hover {
+    color: var(--ink-primary);
+}
+
+#session_table th.sort-asc::after {
+    content: " ▲";
+    color: var(--accent);
+}
+
+#session_table th.sort-desc::after {
+    content: " ▼";
+    color: var(--accent);
+}
+
+#session_table button.session-edit-btn {
+    background: transparent;
+    color: var(--ink-secondary);
+    border: 1px solid var(--hairline);
+    border-radius: 4px;
+    padding: 2px 10px;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+#session_table button.session-edit-btn:hover {
+    background: var(--accent-wash);
+    color: var(--ink-primary);
+}
+
+.empty-state {
+    padding: 24px;
+    text-align: center;
+    color: var(--ink-muted);
+}
+
+/* Highlighted session row when clicking a bar segment: accent wash instead
+   of the old light-yellow block, which glared on the dark surface */
+.session-highlighted td {
+    background: var(--accent-wash);
+    color: var(--ink-primary);
+    font-weight: 600;
+    border-color: var(--accent);
     transition: background 0.2s ease-in-out;
 }
 
-/* Slightly darker border to improve readability on highlight */
-.session-highlighted td {
-    border-color: #e0c263;
+/* ---------- Edit modal ---------- */
+
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+}
+
+.modal-content {
+    background: var(--surface-raised);
+    border: 1px solid var(--hairline);
+    border-radius: 6px;
+    padding: 20px;
+    max-width: 640px;
+    width: 90%;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
+.session-event-row {
+    display: grid;
+    grid-template-columns: 80px 1fr 1fr;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.session-event-row input {
+    background: var(--surface);
+    color: var(--ink-primary);
+    border: 1px solid var(--hairline);
+    border-radius: 4px;
+    padding: 4px 6px;
+    width: 100%;
+    box-sizing: border-box;
+    font-family: inherit;
+    color-scheme: dark;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 16px;
+}
+
+.modal-actions button {
+    padding: 6px 16px;
+    background: transparent;
+    color: var(--ink-secondary);
+    border: 1px solid var(--hairline);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.modal-actions button:hover {
+    background: var(--accent-wash);
+    color: var(--ink-primary);
 }

--- a/src/dashboard/webview/dashboard.css
+++ b/src/dashboard/webview/dashboard.css
@@ -164,6 +164,13 @@ h2, h3 {
     white-space: nowrap;
 }
 
+.legend-hours {
+    color: var(--ink-muted);
+    font-weight: 400;
+    font-size: 13px;
+    white-space: nowrap;
+}
+
 .legend-all {
     border-bottom: 1px solid var(--hairline);
     margin-bottom: 4px;

--- a/src/dashboard/webview/dashboard.css
+++ b/src/dashboard/webview/dashboard.css
@@ -259,6 +259,31 @@ h2, h3 {
     color-scheme: dark;
 }
 
+/* The job list scrolls inside the menu so the Clear button stays visible */
+#job_dropdown_list {
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+.menu-clear {
+    display: block;
+    width: 100%;
+    margin-top: 8px;
+    padding: 4px 8px;
+    background: transparent;
+    color: var(--ink-secondary);
+    border: 1px solid var(--hairline);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 12px;
+}
+
+.menu-clear:hover {
+    background: var(--accent-wash);
+    color: var(--ink-primary);
+}
+
 .dropdown-row {
     display: block;
     padding: 3px 4px;

--- a/src/dashboard/webview/dashboard.css
+++ b/src/dashboard/webview/dashboard.css
@@ -177,60 +177,45 @@ h2, h3 {
     max-height: 350px;
 }
 
-/* ---------- Session filter row ---------- */
+/* ---------- Column filter menus (funnel in the header) ---------- */
 
-#session_filter_row {
-    display: flex;
-    flex-wrap: wrap;
+.col-filter {
+    display: inline-block;
+    position: relative;
+    vertical-align: middle;
+    margin-left: 6px;
+}
+
+.col-filter summary {
+    list-style: none;
+    cursor: pointer;
+    display: inline-flex;
     align-items: center;
-    gap: 20px;
-    margin-bottom: 12px;
-}
-
-.filter-field {
-    flex-direction: row;
-    align-items: center;
-    gap: 6px;
-}
-
-.filter-field input[type="number"] {
-    width: 64px;
-}
-
-.range-sep {
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
     color: var(--ink-muted);
 }
 
-/* Job dropdown (native <details>) */
-
-.job-dropdown {
-    position: relative;
-}
-
-.job-dropdown summary {
-    list-style: none;
-    cursor: pointer;
-    background: var(--surface);
-    color: var(--ink-primary);
-    border: 1px solid var(--hairline);
-    border-radius: 4px;
-    padding: 4px 24px 4px 8px;
-    min-width: 100px;
-}
-
-.job-dropdown summary::-webkit-details-marker {
+.col-filter summary::-webkit-details-marker {
     display: none;
 }
 
-.job-dropdown summary::after {
-    content: "▾";
-    position: absolute;
-    right: 8px;
-    color: var(--ink-muted);
+.col-filter summary:hover {
+    background: var(--accent-wash);
+    color: var(--ink-primary);
 }
 
-.job-dropdown-list {
+/* Funnel lights up when its filter is actively limiting data */
+.col-filter summary.filter-active {
+    color: var(--accent);
+}
+
+.col-filter-menu {
     position: absolute;
+    top: 100%;
+    left: 0;
     z-index: 10;
     margin-top: 4px;
     max-height: 260px;
@@ -238,9 +223,33 @@ h2, h3 {
     background: var(--surface-raised);
     border: 1px solid var(--hairline);
     border-radius: 4px;
-    padding: 6px;
-    min-width: 160px;
+    padding: 8px;
+    min-width: 170px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    text-transform: none;
+    letter-spacing: normal;
+    font-weight: 400;
+    font-size: 13px;
+    color: var(--ink-secondary);
+}
+
+.range-menu label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 3px 0;
+}
+
+.range-menu input[type="number"] {
+    width: 72px;
+    background: var(--surface);
+    color: var(--ink-primary);
+    border: 1px solid var(--hairline);
+    border-radius: 4px;
+    padding: 4px 6px;
+    font-family: inherit;
+    color-scheme: dark;
 }
 
 .dropdown-row {
@@ -249,6 +258,7 @@ h2, h3 {
     cursor: pointer;
     white-space: nowrap;
     border-radius: 3px;
+    color: var(--ink-primary);
 }
 
 .dropdown-row:hover {
@@ -289,19 +299,31 @@ h2, h3 {
 #session_table th.sortable {
     cursor: pointer;
     user-select: none;
+    white-space: nowrap;
+    position: relative;
+    overflow: visible;
 }
 
-#session_table th.sortable:hover {
+#session_table th.sortable:hover .th-label {
     color: var(--ink-primary);
 }
 
-#session_table th.sort-asc::after {
+/* Sortable columns always show a (dimmed) direction hint; the active sort
+   column shows its direction in the accent color */
+#session_table th.sortable .th-label::after {
+    content: " ↕";
+    opacity: 0.35;
+}
+
+#session_table th.sort-asc .th-label::after {
     content: " ▲";
+    opacity: 1;
     color: var(--accent);
 }
 
-#session_table th.sort-desc::after {
+#session_table th.sort-desc .th-label::after {
     content: " ▼";
+    opacity: 1;
     color: var(--accent);
 }
 

--- a/src/dashboard/webview/dashboard.js
+++ b/src/dashboard/webview/dashboard.js
@@ -2,6 +2,9 @@ console.log("dashboard.js loaded");
 
 const vscode = acquireVsCodeApi();
 
+// Pure filter/sort logic shared with the Node test suite (filter_state.js).
+const Filters = window.TimeScopeFilters;
+
 // Request data from extension
 vscode.postMessage({
     type: "request_data"
@@ -12,7 +15,13 @@ let all_events = []; // ascending events used to build sessions and compute paus
 let eventOccurrencesMap = new Map(); // key -> occurrences array
 let pie_chart_instance = null;
 let stacked_chart_instance = null;
-let hasRenderedJobFilter = false;
+
+// One filter state object drives every chart and the table.
+let filter_state = Filters.create_default_filter_state(new Date());
+
+// job -> colour, assigned once from the full job list so filtering never
+// reshuffles the palette.
+let job_color_map = {};
 
 // Current highlighted job/day (for toggle behavior)
 let current_highlight = null;
@@ -30,32 +39,14 @@ window.addEventListener("message", (event) => {
         const footer = document.getElementById('build_info_footer');
         if (footer) footer.textContent = msg.build_info || 'no build info';
 
-        // payload is an array of grouped events { event, job, timestamp, task, occurrences }
+        load_payload(payload);
 
-        // Build canonical events array (ascending order) for session construction
-        // Preserve id, job_id, time_seed so edits can send a complete DTO back
-        const eventsAsc = payload
-            .map(e => ({ event: e.event, job: e.job, task: e.task, timestamp: e.timestamp, id: e.id, job_id: e.job_id, time_seed: e.time_seed }))
-            .sort((a, b) => a.timestamp - b.timestamp);
-
-        // keep all_events for pause/resume counts and session edit mapping
-        all_events = eventsAsc;
-
-        // Build occurrences map for quick lookup when editing
-        eventOccurrencesMap = new Map();
-        payload.forEach(e => {
-            const key = `${e.event}|${e.job}|${e.timestamp}|${e.task || ""}`;
-            eventOccurrencesMap.set(key, e.occurrences || []);
-        });
-
-        // 2) Build sessions from start/pause/resume/stop event stream
-        all_sessions = build_sessions_from_events(eventsAsc);
-
-        // 3) Initial render + filter hookup
-        render_dashboard(all_sessions);
+        // Initial render applies the default filter state (Last 14 Days),
+        // fixing the old "default preset never applied on load" bug (#31).
+        render_date_controls();
+        render_filter_controls();
         attach_filter_listeners();
-
-        // Event log removed; session-based editing is available via Edit buttons in the Sessions table.
+        apply_and_render();
     }
 
     if (msg.type === "edit_result") {
@@ -72,7 +63,7 @@ window.addEventListener("message", (event) => {
             if (result && result.warnings && result.warnings.length > 0) {
                 warningBox.style.display = '';
                 const wMsgs = result.warnings.map(w => (typeof w === 'string' ? w : (w.message || JSON.stringify(w))));
-                warningBox.textContent = '\u26A0 ' + wMsgs.join('\n\u26A0 ');
+                warningBox.textContent = '⚠ ' + wMsgs.join('\n⚠ ');
             } else {
                 warningBox.style.display = 'none';
                 warningBox.textContent = '';
@@ -95,10 +86,10 @@ window.addEventListener("message", (event) => {
             return;
         }
 
-        // success — refresh UI with new payload
-        const eventsAsc = payload.map(e => ({ event: e.event, job: e.job, task: e.task, timestamp: e.timestamp, id: e.id, job_id: e.job_id, time_seed: e.time_seed })).sort((a, b) => a.timestamp - b.timestamp);
-        all_sessions = build_sessions_from_events(eventsAsc);
-        render_dashboard(all_sessions);
+        // success — refresh UI with new payload (keeps current filter state)
+        load_payload(payload);
+        render_filter_controls();
+        apply_and_render();
 
         // If there are warnings but no errors, keep the modal open so the user sees them
         if (result && result.warnings && result.warnings.length > 0) {
@@ -110,47 +101,35 @@ window.addEventListener("message", (event) => {
 });
 
 // ---------------------------------------------------------------------
-// NORMALIZATION: RAW EVENTS → CANONICAL EVENTS
+// PAYLOAD → SESSIONS
 // ---------------------------------------------------------------------
 
-function normalize_events(rawEvents) {
-    // 1) Normalize
-    let events = rawEvents
-        .map(e => {
-            const evt = e.event || e.type;
-            const job = e.job || "";
-            const task = e.task || "";
+function load_payload(payload) {
+    // Canonical events array (ascending) for session construction.
+    // Preserve id, job_id, time_seed (edit DTO) and line indices (source seam).
+    all_events = payload
+        .map(e => ({
+            event: e.event,
+            job: e.job,
+            task: e.task,
+            timestamp: e.timestamp,
+            id: e.id,
+            job_id: e.job_id,
+            time_seed: e.time_seed,
+            global_line_index: e.global_line_index,
+            workspace_line_index: e.workspace_line_index,
+        }))
+        .sort((a, b) => a.timestamp - b.timestamp);
 
-            const tsRaw = e.timestamp;
-            let ts;
-            if (typeof tsRaw === "number") ts = tsRaw;
-            else if (typeof tsRaw === "string") {
-                if (/^\d+$/.test(tsRaw.trim())) ts = Number(tsRaw);
-                else ts = Date.parse(tsRaw);
-            } else ts = NaN;
-
-            return { event: evt, job, task, timestamp: ts };
-        })
-        .filter(e =>
-            e.event &&
-            e.job &&
-            typeof e.timestamp === "number" &&
-            !Number.isNaN(e.timestamp)
-        );
-
-    // 2) DEDUPE (fixes global+workspace mirror duplication)
-    const seen = new Set();
-    events = events.filter(e => {
+    // Occurrences map for the edit modal
+    eventOccurrencesMap = new Map();
+    payload.forEach(e => {
         const key = `${e.event}|${e.job}|${e.timestamp}|${e.task || ""}`;
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
+        eventOccurrencesMap.set(key, e.occurrences || []);
     });
 
-    // 3) Sort
-    events.sort((a, b) => a.timestamp - b.timestamp);
-
-    return events;
+    all_sessions = build_sessions_from_events(all_events);
+    assign_job_colors(all_sessions);
 }
 
 // ---------------------------------------------------------------------
@@ -162,7 +141,7 @@ function normalize_events(rawEvents) {
 //   start → pause → resume → stop
 //   start → pause → resume → pause → resume → stop
 //
-// Each job has its own state; we assume you’re not running the same job
+// Each job has its own state; we assume you're not running the same job
 // concurrently in multiple overlapping sessions.
 
 function build_sessions_from_events(events) {
@@ -177,10 +156,18 @@ function build_sessions_from_events(events) {
                 currentSession: null,
                 lastActiveStart: null,
                 accumulatedMs: 0,
-                inPause: false
+                inPause: false,
+                pausePairs: 0,
+                hasGlobal: false,
+                hasWorkspace: false
             });
         }
         return stateByJob.get(job);
+    }
+
+    function noteSource(state, e) {
+        if (typeof e.global_line_index === "number" && e.global_line_index >= 0) state.hasGlobal = true;
+        if (typeof e.workspace_line_index === "number" && e.workspace_line_index >= 0) state.hasWorkspace = true;
     }
 
     function finalizeSession(job, stopTs, stopTask) {
@@ -199,7 +186,10 @@ function build_sessions_from_events(events) {
             start: state.currentSession.start,
             stop: stopTs,
             duration_ms,
-            task: stopTask || state.currentSession.task || ""
+            task: stopTask || state.currentSession.task || "",
+            pause_pairs: state.pausePairs,
+            has_global: state.hasGlobal,
+            has_workspace: state.hasWorkspace
         });
 
         // Reset state for this job
@@ -207,6 +197,9 @@ function build_sessions_from_events(events) {
         state.lastActiveStart = null;
         state.accumulatedMs = 0;
         state.inPause = false;
+        state.pausePairs = 0;
+        state.hasGlobal = false;
+        state.hasWorkspace = false;
     }
 
     for (const e of events) {
@@ -230,6 +223,10 @@ function build_sessions_from_events(events) {
                 state.lastActiveStart = ts;
                 state.accumulatedMs = 0;
                 state.inPause = false;
+                state.pausePairs = 0;
+                state.hasGlobal = false;
+                state.hasWorkspace = false;
+                noteSource(state, e);
                 break;
             }
 
@@ -238,6 +235,7 @@ function build_sessions_from_events(events) {
                     state.accumulatedMs += ts - state.lastActiveStart;
                     state.lastActiveStart = null;
                     state.inPause = true;
+                    noteSource(state, e);
                 }
                 break;
             }
@@ -246,12 +244,15 @@ function build_sessions_from_events(events) {
                 if (state.currentSession && state.inPause) {
                     state.inPause = false;
                     state.lastActiveStart = ts;
+                    state.pausePairs += 1;
+                    noteSource(state, e);
                 }
                 break;
             }
 
             case "stop": {
                 if (state.currentSession) {
+                    noteSource(state, e);
                     finalizeSession(job, ts, e.task);
                 }
                 break;
@@ -269,231 +270,324 @@ function build_sessions_from_events(events) {
 }
 
 // ---------------------------------------------------------------------
-// FILTER LISTENERS
+// STABLE PALETTE
 // ---------------------------------------------------------------------
 
-function attach_filter_listeners() {
-    const preset = document.getElementById("preset_range");
-    if (preset && !preset.dataset.bound) {
-        preset.addEventListener("change", apply_filters_and_render);
-        preset.dataset.bound = "true";
-    }
-
-    const clearBtn = document.getElementById("clear_filters_btn");
-    if (clearBtn && !clearBtn.dataset.bound) {
-        clearBtn.addEventListener("click", clear_filters);
-        clearBtn.dataset.bound = "true";
-    }
-
-    // “All” checkbox
-    const allBox = document.getElementById("job_all_checkbox");
-    if (allBox && !allBox.dataset.bound) {
-        allBox.addEventListener("change", () => {
-            const checked = allBox.checked;
-            document
-                .querySelectorAll("#job_filter_container .job-box")
-                .forEach(box => {
-                    box.checked = checked;
-                });
-            apply_filters_and_render();
-        });
-        allBox.dataset.bound = "true";
-    }
-
-    // Individual job boxes
-    document
-        .querySelectorAll("#job_filter_container .job-box")
-        .forEach(box => {
-            if (!box.dataset.bound) {
-                box.addEventListener("change", () => {
-                    const allBox = document.getElementById("job_all_checkbox");
-                    const allJobs = [
-                        ...document.querySelectorAll("#job_filter_container .job-box")
-                    ];
-                    const allChecked = allJobs.every(b => b.checked);
-                    if (allBox) {
-                        allBox.checked = allChecked;
-                    }
-                    apply_filters_and_render();
-                });
-                box.dataset.bound = "true";
-            }
-        });
+function assign_job_colors(allSessions) {
+    // Validated categorical palette (dark surface #1e1e1e): passes lightness,
+    // chroma, CVD-separation, normal-vision and contrast checks in this order.
+    // Past 10 jobs the palette wraps — colour alone no longer identifies a job,
+    // which is why the legend and table carry the names.
+    const base = [
+        "#3987e5", "#008300", "#d55181", "#c98500",
+        "#199e70", "#d95926", "#9085e9", "#e66767",
+        "#8a8a3a", "#b06a9e"
+    ];
+    // Alphabetical order → a job keeps the same colour across data reloads.
+    const jobs = [...new Set(allSessions.map(s => s.job))].sort((a, b) => a.localeCompare(b));
+    job_color_map = {};
+    jobs.forEach((job, i) => {
+        job_color_map[job] = base[i % base.length];
+    });
 }
+
+function color_for(job) {
+    return job_color_map[job] || "#898781";
+}
+
+// Chart chrome tokens (match dashboard.css)
+const CHART_SURFACE = "#1e1e1e";
+const CHART_INK_SECONDARY = "#c3c2b7";
+const CHART_GRIDLINE = "#2c2c2a";
 
 // ---------------------------------------------------------------------
 // MAIN FILTER PIPELINE
 // ---------------------------------------------------------------------
 
-function apply_filters_and_render() {
-    const filtered = filter_sessions(all_sessions);
-    render_dashboard(filtered);
+function apply_and_render() {
+    let filtered = Filters.apply_filters(all_sessions, filter_state);
+    filtered = Filters.sort_sessions(filtered, filter_state.sort_key, filter_state.sort_dir);
+
+    render_pie_chart(filtered);
+    render_stacked_bar_chart(filtered);
+    render_session_table(filtered);
+    render_empty_state(filtered);
+    render_sort_indicators();
 }
 
 // ---------------------------------------------------------------------
-// DATE + JOB FILTERING
+// DATE CONTROLS
 // ---------------------------------------------------------------------
 
-function filter_sessions(sessions) {
-    const presetEl = document.getElementById("preset_range");
-    const preset = presetEl ? presetEl.value : "this_month";
+function render_date_controls() {
+    const preset = document.getElementById("preset_range");
+    if (preset) preset.value = filter_state.preset;
+    set_date_inputs(filter_state.start_day, filter_state.end_day);
+}
 
-    const now = new Date();
-    const today_local = get_local_day(now.getTime());
-
-    let start_date = null;
-    let end_date = null;
-
-    if (preset === "today") {
-        start_date = today_local;
-        end_date = today_local;
-    }
-
-    if (preset === "this_week") {
-        const day = now.getDay();
-        const monday = new Date(now);
-        monday.setDate(now.getDate() - ((day + 6) % 7));
-        start_date = get_local_day(monday.getTime());
-        end_date = today_local;
-    }
-
-    if (preset === "last_7") {
-        const d = new Date(now);
-        d.setDate(now.getDate() - 6);
-        start_date = get_local_day(d.getTime());
-        end_date = today_local;
-    }
-
-    if (preset === "this_month") {
-        const first = new Date(now.getFullYear(), now.getMonth(), 1);
-        start_date = get_local_day(first.getTime());
-        end_date = today_local;
-    }
-
-    if (preset === "last_3_months") {
-        const d = new Date(now);
-        d.setMonth(now.getMonth() - 2);
-        const first = new Date(d.getFullYear(), d.getMonth(), 1);
-        start_date = get_local_day(first.getTime());
-        end_date = today_local;
-    }
-
-    let date_filtered = sessions;
-
-    if (start_date && end_date) {
-        date_filtered = sessions.filter(s => {
-            const day = get_local_day(s.start);
-            return day >= start_date && day <= end_date;
-        });
-    }
-
-    // JOB FILTERING — only job boxes, ignore "All"
-    const selected_jobs = [
-        ...document.querySelectorAll("#job_filter_container .job-box:checked")
-    ].map(b => b.value);
-
-    if (selected_jobs.length === 0) {
-        return [];
-    }
-
-    return date_filtered.filter(s => selected_jobs.includes(s.job));
+function set_date_inputs(start_day, end_day) {
+    const startEl = document.getElementById("start_date");
+    const endEl = document.getElementById("end_date");
+    if (startEl) startEl.value = start_day || "";
+    if (endEl) endEl.value = end_day || "";
 }
 
 // ---------------------------------------------------------------------
-// DASHBOARD RENDERER
+// JOB LEGEND + TABLE DROPDOWN (two synced surfaces, one selection)
 // ---------------------------------------------------------------------
 
-function render_dashboard(sessions) {
-    render_job_filter(all_sessions);
-    attach_filter_listeners();
-    render_pie_chart(sessions);
-    render_stacked_bar_chart(sessions);
-    render_session_table(sessions);
+function all_job_names() {
+    return [...new Set(all_sessions.map(s => s.job))].sort((a, b) => a.localeCompare(b));
 }
 
-// ---------------------------------------------------------------------
-// JOB FILTER CHECKBOXES (WITH “ALL”)
-// ---------------------------------------------------------------------
+/** Which jobs are currently selected (state.jobs === null means all). */
+function selected_job_set() {
+    if (filter_state.jobs === null) return new Set(all_job_names());
+    return new Set(filter_state.jobs);
+}
 
-function render_job_filter(allSessions) {
-    const container = document.getElementById("job_filter_container");
+function render_filter_controls() {
+    render_job_legend();
+    render_job_dropdown();
+    sync_range_inputs();
+}
+
+function render_job_legend() {
+    const container = document.getElementById("job_legend");
     if (!container) return;
+    const selected = selected_job_set();
+    const jobs = all_job_names();
+    const allChecked = jobs.every(j => selected.has(j));
 
-    // Capture previous selections (job boxes only)
-    const previouslyChecked = new Set(
-        [...container.querySelectorAll("input.job-box")]
-            .filter(b => b.checked)
-            .map(b => b.value)
-    );
+    let html =
+        `<label class="legend-row legend-all">` +
+        `<input type="checkbox" id="job_all_checkbox" ${allChecked ? "checked" : ""}>` +
+        `<span class="legend-swatch" style="visibility:hidden;"></span>` +
+        `<span class="legend-text">All</span></label>`;
 
-    container.innerHTML = "";
-
-    const jobs = [...new Set(allSessions.map(s => s.job))];
-
-    // Determine if "All" should be checked:
-    // - first render → true
-    // - later renders → true if every job was checked previously
-    let allShouldBeChecked;
-    if (!hasRenderedJobFilter) {
-        allShouldBeChecked = true;
-    } else {
-        allShouldBeChecked =
-            jobs.length > 0 &&
-            jobs.every(job => previouslyChecked.has(job));
-    }
-
-    // "All" checkbox
-    const allDiv = document.createElement("div");
-    allDiv.innerHTML =
-        `<label><input type="checkbox" id="job_all_checkbox" ${allShouldBeChecked ? "checked" : ""}> All</label>`;
-    container.appendChild(allDiv);
-
-    // Job checkboxes
     jobs.forEach(job => {
-        const div = document.createElement("div");
-
-        let checked;
-        if (!hasRenderedJobFilter) {
-            // First render → all checked
-            checked = true;
-        } else if (previouslyChecked.size === 0) {
-            checked = allShouldBeChecked;
-        } else {
-            checked = previouslyChecked.has(job);
-        }
-
-        div.innerHTML =
-            `<label><input type="checkbox" class="job-box" value="${job}" ${checked ? "checked" : ""}> ${job}</label>`;
-
-        container.appendChild(div);
+        const checked = selected.has(job) ? "checked" : "";
+        html +=
+            `<label class="legend-row">` +
+            `<input type="checkbox" class="legend-job-box" value="${job}" ${checked}>` +
+            `<span class="legend-swatch" style="background:${color_for(job)};"></span>` +
+            `<span class="legend-text">${job}</span></label>`;
     });
 
-    hasRenderedJobFilter = true;
+    container.innerHTML = html;
+}
+
+function render_job_dropdown() {
+    const list = document.getElementById("job_dropdown_list");
+    if (!list) return;
+    const selected = selected_job_set();
+    const jobs = all_job_names();
+    const allChecked = jobs.every(j => selected.has(j));
+
+    let html =
+        `<label class="dropdown-row">` +
+        `<input type="checkbox" id="job_dropdown_all" ${allChecked ? "checked" : ""}> All</label>`;
+    jobs.forEach(job => {
+        const checked = selected.has(job) ? "checked" : "";
+        html +=
+            `<label class="dropdown-row">` +
+            `<input type="checkbox" class="dropdown-job-box" value="${job}" ${checked}> ${job}</label>`;
+    });
+    list.innerHTML = html;
+
+    update_dropdown_summary();
+}
+
+function update_dropdown_summary() {
+    const summary = document.getElementById("job_dropdown_summary");
+    if (!summary) return;
+    const jobs = all_job_names();
+    const selected = selected_job_set();
+    const count = jobs.filter(j => selected.has(j)).length;
+    if (count === jobs.length) summary.textContent = "All jobs";
+    else if (count === 0) summary.textContent = "No jobs";
+    else if (count === 1) summary.textContent = jobs.find(j => selected.has(j));
+    else summary.textContent = `${count} jobs`;
+}
+
+/**
+ * Update the shared job selection from one surface, then re-render both.
+ * A full set collapses to null so newly appearing jobs stay included.
+ */
+function set_job_selection(jobArray) {
+    const jobs = all_job_names();
+    if (jobArray.length === jobs.length) {
+        filter_state.jobs = null;
+    } else {
+        filter_state.jobs = jobArray;
+    }
+    render_job_legend();
+    render_job_dropdown();
+    apply_and_render();
 }
 
 // ---------------------------------------------------------------------
-// CLEAR FILTERS
+// RANGE INPUTS (duration / pauses)
+// ---------------------------------------------------------------------
+
+function sync_range_inputs() {
+    set_number_input("dur_min", filter_state.duration_min_h);
+    set_number_input("dur_max", filter_state.duration_max_h);
+    set_number_input("pause_min", filter_state.pauses_min);
+    set_number_input("pause_max", filter_state.pauses_max);
+}
+
+function set_number_input(id, value) {
+    const el = document.getElementById(id);
+    if (el) el.value = value === null || value === undefined ? "" : String(value);
+}
+
+function read_number_input(id) {
+    const el = document.getElementById(id);
+    if (!el || el.value.trim() === "") return null;
+    const n = Number(el.value);
+    return Number.isFinite(n) ? n : null;
+}
+
+// ---------------------------------------------------------------------
+// FILTER LISTENERS
+// ---------------------------------------------------------------------
+
+function attach_filter_listeners() {
+    bind_once(document.getElementById("preset_range"), "change", on_preset_change);
+    bind_once(document.getElementById("start_date"), "change", on_date_input_change);
+    bind_once(document.getElementById("end_date"), "change", on_date_input_change);
+    bind_once(document.getElementById("clear_filters_btn"), "click", clear_filters);
+
+    ["dur_min", "dur_max", "pause_min", "pause_max"].forEach(id => {
+        bind_once(document.getElementById(id), "input", on_range_change);
+    });
+
+    // Job legend + dropdown use event delegation so they survive re-renders.
+    bind_once(document.getElementById("job_legend"), "change", on_legend_change);
+    bind_once(document.getElementById("job_dropdown_list"), "change", on_dropdown_change);
+
+    // Sortable headers
+    document.querySelectorAll("#session_table th.sortable").forEach(th => {
+        bind_once(th, "click", () => on_sort_click(th.dataset.sort));
+    });
+}
+
+function bind_once(el, evt, handler) {
+    if (el && !el.dataset.bound) {
+        el.addEventListener(evt, handler);
+        el.dataset.bound = "true";
+    }
+}
+
+function on_preset_change() {
+    const preset = document.getElementById("preset_range").value;
+    filter_state.preset = preset;
+    if (preset !== "custom") {
+        const range = Filters.resolve_preset_range(preset, new Date());
+        filter_state.start_day = range.start_day;
+        filter_state.end_day = range.end_day;
+        set_date_inputs(range.start_day, range.end_day);
+    }
+    apply_and_render();
+}
+
+function on_date_input_change() {
+    let start = document.getElementById("start_date").value || null;
+    let end = document.getElementById("end_date").value || null;
+
+    // Single-day rule: if the other field is empty, mirror the entered date.
+    if (start && !end) end = start;
+    else if (end && !start) start = end;
+
+    filter_state.start_day = start;
+    filter_state.end_day = end;
+    set_date_inputs(start, end);
+
+    // A manual date edit means the range is no longer a named preset.
+    filter_state.preset = "custom";
+    const preset = document.getElementById("preset_range");
+    if (preset) preset.value = "custom";
+
+    apply_and_render();
+}
+
+function on_range_change() {
+    filter_state.duration_min_h = read_number_input("dur_min");
+    filter_state.duration_max_h = read_number_input("dur_max");
+    filter_state.pauses_min = read_number_input("pause_min");
+    filter_state.pauses_max = read_number_input("pause_max");
+    apply_and_render();
+}
+
+function on_legend_change(ev) {
+    const target = ev.target;
+    if (target.id === "job_all_checkbox") {
+        set_job_selection(target.checked ? all_job_names() : []);
+        return;
+    }
+    if (target.classList.contains("legend-job-box")) {
+        set_job_selection(read_checked_values("#job_legend .legend-job-box"));
+    }
+}
+
+function on_dropdown_change(ev) {
+    const target = ev.target;
+    if (target.id === "job_dropdown_all") {
+        set_job_selection(target.checked ? all_job_names() : []);
+        return;
+    }
+    if (target.classList.contains("dropdown-job-box")) {
+        set_job_selection(read_checked_values("#job_dropdown_list .dropdown-job-box"));
+    }
+}
+
+function read_checked_values(selector) {
+    return [...document.querySelectorAll(selector)].filter(b => b.checked).map(b => b.value);
+}
+
+function on_sort_click(sort_key) {
+    if (!sort_key) return;
+    if (filter_state.sort_key === sort_key) {
+        filter_state.sort_dir = filter_state.sort_dir === "asc" ? "desc" : "asc";
+    } else {
+        filter_state.sort_key = sort_key;
+        filter_state.sort_dir = "desc";
+    }
+    apply_and_render();
+}
+
+// ---------------------------------------------------------------------
+// CLEAR / RESET FILTERS
 // ---------------------------------------------------------------------
 
 function clear_filters() {
-    const preset = document.getElementById("preset_range");
-    if (preset) {
-        preset.value = "this_month";
-    }
+    filter_state = Filters.create_default_filter_state(new Date());
+    render_date_controls();
+    render_filter_controls();
+    apply_and_render();
+}
 
-    // Re-check "All" and all jobs
-    const allBox = document.getElementById("job_all_checkbox");
-    if (allBox) {
-        allBox.checked = true;
-    }
+// ---------------------------------------------------------------------
+// SORT INDICATORS
+// ---------------------------------------------------------------------
 
-    document
-        .querySelectorAll("#job_filter_container .job-box")
-        .forEach(box => {
-            box.checked = true;
-        });
+function render_sort_indicators() {
+    document.querySelectorAll("#session_table th.sortable").forEach(th => {
+        th.classList.remove("sort-asc", "sort-desc");
+        if (th.dataset.sort === filter_state.sort_key) {
+            th.classList.add(filter_state.sort_dir === "asc" ? "sort-asc" : "sort-desc");
+        }
+    });
+}
 
-    apply_filters_and_render();
+// ---------------------------------------------------------------------
+// EMPTY STATE
+// ---------------------------------------------------------------------
+
+function render_empty_state(sessions) {
+    const el = document.getElementById("empty_state");
+    if (el) el.style.display = sessions.length === 0 ? "" : "none";
 }
 
 // ---------------------------------------------------------------------
@@ -514,19 +608,27 @@ function render_pie_chart(sessions) {
 
     if (pie_chart_instance) pie_chart_instance.destroy();
 
+    const total_hours = hours.reduce((a, b) => a + b, 0);
+
     pie_chart_instance = new Chart(ctx, {
         type: "pie",
         data: {
             labels: jobs,
             datasets: [{
                 data: hours,
-                backgroundColor: generate_color_palette(jobs.length)
+                backgroundColor: jobs.map(j => color_for(j)),
+                // 2px surface gap between slices
+                borderColor: CHART_SURFACE,
+                borderWidth: 2
             }]
         },
         options: {
             plugins: {
+                legend: { display: false },
                 datalabels: {
-                    formatter: (value) => value.toFixed(1) + "h",
+                    // Selective labels: skip slices under 5% — they'd collide
+                    formatter: (value) =>
+                        total_hours > 0 && value / total_hours < 0.05 ? "" : value.toFixed(1) + "h",
                     color: "#fff",
                     font: { weight: "bold" }
                 }
@@ -546,20 +648,22 @@ function render_stacked_bar_chart(sessions) {
 
     const map = {};
     sessions.forEach(s => {
-        const day = get_local_day(s.start);
+        const day = Filters.get_local_day(s.start);
         map[day] = map[day] || {};
         map[day][s.job] = (map[day][s.job] || 0) + s.duration_ms;
     });
 
     const days = Object.keys(map).sort((a, b) => new Date(a) - new Date(b));
-    const jobs = [...new Set(sessions.map(s => s.job))];
+    const jobs = [...new Set(sessions.map(s => s.job))].sort((a, b) => a.localeCompare(b));
 
-    const palette = generate_color_palette(jobs.length);
-
-    const datasets = jobs.map((job, idx) => ({
+    const datasets = jobs.map(job => ({
         label: job,
         data: days.map(d => (map[d][job] || 0) / 3600000),
-        backgroundColor: palette[idx]
+        backgroundColor: color_for(job),
+        // 2px surface gap between stacked segments and adjacent bars
+        borderColor: CHART_SURFACE,
+        borderWidth: 2,
+        borderSkipped: false
     }));
 
     const totals_per_day = days.map(d =>
@@ -578,28 +682,38 @@ function render_stacked_bar_chart(sessions) {
             responsive: true,
             maintainAspectRatio: false,
             scales: {
-                x: { stacked: true },
+                x: {
+                    stacked: true,
+                    grid: { display: false },
+                    ticks: { color: CHART_INK_SECONDARY }
+                },
                 y: {
                     stacked: true,
                     beginAtZero: true,
-                    suggestedMax: padded_max
+                    suggestedMax: padded_max,
+                    grid: { color: CHART_GRIDLINE },
+                    border: { color: CHART_GRIDLINE },
+                    ticks: { color: CHART_INK_SECONDARY }
                 }
             },
             plugins: {
-                legend: { position: "right" },
+                legend: { display: false },
                 datalabels: {
                     color: "#fff",
                     font: { weight: "bold" },
                     clip: false,
                     offset: 4,
                     formatter: (value, ctx) => {
-                        if (!value) return "";
+                        // The last dataset carries the per-day total, even when
+                        // its own segment is empty that day
                         const last = ctx.chart.data.datasets.length - 1;
                         if (ctx.datasetIndex === last) {
                             const total = totals_per_day[ctx.dataIndex];
-                            return total.toFixed(1) + "h";
+                            return total > 0 ? total.toFixed(1) + "h" : "";
                         }
-                        return value.toFixed(1) + "h";
+                        // Selective labels: segments under 30 min are too short
+                        // for legible text — the tooltip still carries the value
+                        return !value || value < 0.5 ? "" : value.toFixed(1) + "h";
                     },
                     anchor: (ctx) =>
                         ctx.datasetIndex === ctx.chart.data.datasets.length - 1
@@ -722,7 +836,6 @@ function open_session_edit_modal(session) {
 
             // UI: disable save and show progress
             save.disabled = true;
-            const prevText = save.textContent;
             save.textContent = 'Saving…';
 
             // Clear previous errors
@@ -749,25 +862,16 @@ function render_session_table(sessions) {
 
     body.innerHTML = "";
 
-    // Show latest sessions first (reverse chronological)
-    const rev = sessions.slice().sort((a, b) => b.start - a.start);
-
     // Clear any previous highlights
     clear_session_highlights();
 
-    rev.forEach(s => {
+    sessions.forEach(s => {
         const tr = document.createElement("tr");
 
-        const day = get_local_day(s.start);
+        const day = Filters.get_local_day(s.start);
 
         const start_local = new Date(s.start).toLocaleString();
         const stop_local = new Date(s.stop).toLocaleString();
-
-        // Compute pause/resume pair count for this session
-        const eventsForSession = all_events.filter(e => e.job === s.job && e.timestamp >= s.start && e.timestamp <= s.stop);
-        const pauseCount = eventsForSession.filter(e => e.event === 'pause').length;
-        const resumeCount = eventsForSession.filter(e => e.event === 'resume').length;
-        const pairs = Math.min(pauseCount, resumeCount);
 
         const editBtn = `<button class="session-edit-btn" data-job="${s.job}" data-start="${s.start}" data-stop="${s.stop}">Edit</button>`;
 
@@ -781,26 +885,11 @@ function render_session_table(sessions) {
             `<td>${s.task || ""}</td>` +
             `<td>${start_local}</td>` +
             `<td>${stop_local}</td>` +
-            `<td>${pairs}</td>` +
+            `<td>${s.pause_pairs}</td>` +
             `<td>${editBtn}</td>`;
 
         body.appendChild(tr);
     });
-
-    // Attach session edit handlers
-    document.querySelectorAll("button.session-edit-btn").forEach(btn => {
-        if (!btn.dataset.bound) {
-            btn.addEventListener('click', (ev) => {
-                const el = ev.currentTarget;
-                const job = el.getAttribute('data-job');
-                const start = Number(el.getAttribute('data-start'));
-                const stop = Number(el.getAttribute('data-stop'));
-                open_session_edit_modal({ job, start, stop });
-            });
-            btn.dataset.bound = 'true';
-        }
-    });
-
 
     // Attach session edit handlers
     document.querySelectorAll("button.session-edit-btn").forEach(btn => {
@@ -820,25 +909,6 @@ function render_session_table(sessions) {
 // ---------------------------------------------------------------------
 // UTILITIES
 // ---------------------------------------------------------------------
-
-function generate_color_palette(n) {
-    const base = [
-        "#4e79a7", "#f28e2b", "#e15759", "#76b7b2",
-        "#59a14f", "#edc949", "#af7aa1", "#ff9da7",
-        "#9c755f", "#bab0ab"
-    ];
-    return Array.from({ length: n }, (_, i) => base[i % base.length]);
-}
-
-function get_local_day(timestamp) {
-    const d = new Date(timestamp);
-
-    const year = d.getFullYear();
-    const month = String(d.getMonth() + 1).padStart(2, "0");
-    const day = String(d.getDate()).padStart(2, "0");
-
-    return `${year}-${month}-${day}`;  // local ISO date
-}
 
 // Highlight helpers (module-level so chart click handler can call them)
 function clear_session_highlights() {

--- a/src/dashboard/webview/dashboard.js
+++ b/src/dashboard/webview/dashboard.js
@@ -564,6 +564,24 @@ function attach_filter_listeners() {
         });
     });
 
+    // Per-column Clear buttons: remove just that column's filter, close the menu
+    bind_once(document.getElementById("job_filter_clear"), "click", () => {
+        set_job_selection(all_job_names().slice());
+        close_all_filter_menus();
+    });
+    bind_once(document.getElementById("dur_filter_clear"), "click", () => {
+        set_number_input("dur_min", null);
+        set_number_input("dur_max", null);
+        on_range_change();
+        close_all_filter_menus();
+    });
+    bind_once(document.getElementById("pause_filter_clear"), "click", () => {
+        set_number_input("pause_min", null);
+        set_number_input("pause_max", null);
+        on_range_change();
+        close_all_filter_menus();
+    });
+
     // Sortable headers — clicks inside a funnel menu must not change the sort
     document.querySelectorAll("#session_table th.sortable").forEach(th => {
         bind_once(th, "click", (ev) => {

--- a/src/dashboard/webview/dashboard.js
+++ b/src/dashboard/webview/dashboard.js
@@ -423,19 +423,38 @@ function render_job_legend() {
 
 function render_job_dropdown() {
     render_job_picker(JOB_PICKER_SURFACES[1]);
-    update_dropdown_summary();
+    render_filter_indicators();
 }
 
-function update_dropdown_summary() {
-    const summary = document.getElementById("job_dropdown_summary");
-    if (!summary) return;
+/**
+ * Light up each column's funnel when its filter is actively limiting data,
+ * and carry the detail in the tooltip.
+ */
+function render_filter_indicators() {
     const jobs = all_job_names();
     const selected = selected_job_set();
-    const count = jobs.filter(j => selected.has(j)).length;
-    if (count === jobs.length) summary.textContent = "All jobs";
-    else if (count === 0) summary.textContent = "No jobs";
-    else if (count === 1) summary.textContent = jobs.find(j => selected.has(j));
-    else summary.textContent = `${count} jobs`;
+    const job_active = filter_state.jobs !== null && selected.size < jobs.length;
+    set_funnel_state("job_filter_toggle", job_active,
+        job_active ? `Filtering: ${selected.size} of ${jobs.length} jobs` : "Filter by job");
+
+    const dur_active = filter_state.duration_min_h !== null || filter_state.duration_max_h !== null;
+    set_funnel_state("dur_filter_toggle", dur_active,
+        dur_active ? "Duration filter active" : "Filter by duration");
+
+    const pause_active = filter_state.pauses_min !== null || filter_state.pauses_max !== null;
+    set_funnel_state("pause_filter_toggle", pause_active,
+        pause_active ? "Pause filter active" : "Filter by pause count");
+}
+
+function set_funnel_state(id, active, tooltip) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.classList.toggle("filter-active", active);
+    el.title = tooltip;
+}
+
+function close_all_filter_menus() {
+    document.querySelectorAll("details.col-filter[open]").forEach(d => { d.open = false; });
 }
 
 /**
@@ -510,11 +529,56 @@ function attach_filter_listeners() {
         });
     });
 
-    // Sortable headers
+    // Sortable headers — clicks inside a funnel menu must not change the sort
     document.querySelectorAll("#session_table th.sortable").forEach(th => {
-        bind_once(th, "click", () => on_sort_click(th.dataset.sort));
+        bind_once(th, "click", (ev) => {
+            if (ev.target.closest("details.col-filter")) return;
+            on_sort_click(th.dataset.sort);
+        });
     });
+
+    // Column filter menus: one open at a time
+    document.querySelectorAll("details.col-filter").forEach(d => {
+        bind_once(d, "toggle", () => {
+            if (d.open) {
+                document.querySelectorAll("details.col-filter[open]").forEach(other => {
+                    if (other !== d) other.open = false;
+                });
+            }
+        });
+    });
+
+    // Document-level bindings (guarded — attach_filter_listeners can re-run)
+    if (!document_listeners_bound) {
+        document_listeners_bound = true;
+
+        // Click outside any open funnel menu closes it
+        document.addEventListener("click", (ev) => {
+            if (!ev.target.closest("details.col-filter")) close_all_filter_menus();
+        });
+
+        // Keyboard: in the edit modal Enter saves / Escape cancels;
+        // elsewhere Escape closes any open funnel menu
+        document.addEventListener("keydown", (ev) => {
+            const modal = document.getElementById("session_edit_modal");
+            const modal_open = modal && modal.style.display !== "none";
+            if (modal_open) {
+                if (ev.key === "Enter") {
+                    ev.preventDefault();
+                    const save = document.getElementById("session_edit_save");
+                    if (save && !save.disabled) save.click();
+                } else if (ev.key === "Escape") {
+                    ev.preventDefault();
+                    close_session_modal();
+                }
+                return;
+            }
+            if (ev.key === "Escape") close_all_filter_menus();
+        });
+    }
 }
+
+let document_listeners_bound = false;
 
 function bind_once(el, evt, handler) {
     if (el && !el.dataset.bound) {
@@ -568,6 +632,7 @@ function on_range_change() {
     filter_state.duration_max_h = read_number_input("dur_max");
     filter_state.pauses_min = read_number_input("pause_min");
     filter_state.pauses_max = read_number_input("pause_max");
+    render_filter_indicators();
     apply_and_render();
 }
 

--- a/src/dashboard/webview/dashboard.js
+++ b/src/dashboard/webview/dashboard.js
@@ -328,6 +328,8 @@ function apply_and_render() {
     render_session_table(filtered);
     render_empty_state(filtered);
     render_sort_indicators();
+    // Legend hours track the date/range filters, so refresh it too
+    render_job_legend();
 }
 
 // ---------------------------------------------------------------------
@@ -391,7 +393,7 @@ const JOB_PICKER_SURFACES = [
     },
 ];
 
-function job_picker_row(surface, job, checked) {
+function job_picker_row(surface, job, checked, hours_label) {
     const swatch = surface.swatches
         ? (job === null
             ? `<span class="legend-swatch" style="visibility:hidden;"></span>`
@@ -401,24 +403,45 @@ function job_picker_row(surface, job, checked) {
         ? `<input type="checkbox" id="${surface.all_id}" ${checked ? "checked" : ""}>`
         : `<input type="checkbox" class="${surface.box_class}" value="${escape_html(job)}" ${checked ? "checked" : ""}>`;
     const text = job === null ? "All" : escape_html(job);
+    const hours = hours_label === undefined ? "" : `<span class="legend-hours">(${hours_label})</span>`;
     const row_class = job === null ? surface.all_row_class : surface.row_class;
-    return `<label class="${row_class}">${input}${swatch}<span class="legend-text">${text}</span></label>`;
+    return `<label class="${row_class}">${input}${swatch}<span class="legend-text">${text}</span>${hours}</label>`;
 }
 
-function render_job_picker(surface) {
+function render_job_picker(surface, totals) {
     const container = document.getElementById(surface.container_id);
     if (!container) return;
     const selected = selected_job_set();
     const jobs = all_job_names();
     const all_checked = jobs.every(j => selected.has(j));
 
+    const hours_for = (job) => {
+        if (!totals) return undefined;
+        const ms = job === null
+            ? Object.values(totals).reduce((a, b) => a + b, 0)
+            : (totals[job] || 0);
+        return (ms / 3600000).toFixed(1) + "h";
+    };
+
     container.innerHTML =
-        job_picker_row(surface, null, all_checked) +
-        jobs.map(job => job_picker_row(surface, job, selected.has(job))).join("");
+        job_picker_row(surface, null, all_checked, hours_for(null)) +
+        jobs.map(job => job_picker_row(surface, job, selected.has(job), hours_for(job))).join("");
+}
+
+/**
+ * Per-job totals under the current date/duration/pause/source filters but
+ * ignoring the job selection itself — so unchecking a job doesn't zero its
+ * legend number, it keeps telling you what checking it would bring back.
+ */
+function job_totals_ignoring_job_filter() {
+    const sessions = Filters.apply_filters(all_sessions, { ...filter_state, jobs: null });
+    const totals = {};
+    sessions.forEach(s => { totals[s.job] = (totals[s.job] || 0) + s.duration_ms; });
+    return totals;
 }
 
 function render_job_legend() {
-    render_job_picker(JOB_PICKER_SURFACES[0]);
+    render_job_picker(JOB_PICKER_SURFACES[0], job_totals_ignoring_job_filter());
 }
 
 function render_job_dropdown() {
@@ -506,10 +529,22 @@ function attach_filter_listeners() {
     bind_once(document.getElementById("end_date"), "change", on_date_input_change);
     bind_once(document.getElementById("clear_filters_btn"), "click", clear_filters);
 
-    // Debounced: re-filtering destroys/rebuilds both charts, so don't do it
-    // per keystroke while a number is being typed.
+    // Range filters commit on Enter or on leaving the field (native "change"),
+    // never per keystroke — typing "0.5" must not transiently filter on "0".
+    // Enter also closes the menu.
     ["dur_min", "dur_max", "pause_min", "pause_max"].forEach(id => {
-        bind_once(document.getElementById(id), "input", debounce(on_range_change, 150));
+        const el = document.getElementById(id);
+        if (el && !el.dataset.bound) {
+            el.addEventListener("change", on_range_change);
+            el.addEventListener("keydown", (ev) => {
+                if (ev.key === "Enter") {
+                    ev.preventDefault();
+                    on_range_change();
+                    close_all_filter_menus();
+                }
+            });
+            el.dataset.bound = "true";
+        }
     });
 
     // Job legend + dropdown use event delegation so they survive re-renders.
@@ -585,14 +620,6 @@ function bind_once(el, evt, handler) {
         el.addEventListener(evt, handler);
         el.dataset.bound = "true";
     }
-}
-
-function debounce(fn, wait_ms) {
-    let timer = null;
-    return function (...args) {
-        if (timer) clearTimeout(timer);
-        timer = setTimeout(() => { timer = null; fn.apply(this, args); }, wait_ms);
-    };
 }
 
 function on_preset_change() {

--- a/src/dashboard/webview/dashboard.js
+++ b/src/dashboard/webview/dashboard.js
@@ -403,9 +403,11 @@ function job_picker_row(surface, job, checked, hours_label) {
         ? `<input type="checkbox" id="${surface.all_id}" ${checked ? "checked" : ""}>`
         : `<input type="checkbox" class="${surface.box_class}" value="${escape_html(job)}" ${checked ? "checked" : ""}>`;
     const text = job === null ? "All" : escape_html(job);
+    // Tooltip carries the full name in case the row truncates it
+    const tooltip = job === null ? "" : ` title="${escape_html(job)}"`;
     const hours = hours_label === undefined ? "" : `<span class="legend-hours">(${hours_label})</span>`;
     const row_class = job === null ? surface.all_row_class : surface.row_class;
-    return `<label class="${row_class}">${input}${swatch}<span class="legend-text">${text}</span>${hours}</label>`;
+    return `<label class="${row_class}">${input}${swatch}<span class="legend-text"${tooltip}>${text}</span>${hours}</label>`;
 }
 
 function render_job_picker(surface, totals) {
@@ -736,8 +738,15 @@ function render_sort_indicators() {
 // ---------------------------------------------------------------------
 
 function render_empty_state(sessions) {
+    const empty = sessions.length === 0;
     const el = document.getElementById("empty_state");
-    if (el) el.style.display = sessions.length === 0 ? "" : "none";
+    if (el) el.style.display = empty ? "" : "none";
+    // Prominent message in place of the pie chart — the likeliest cause is a
+    // too-narrow date range, so point the user there
+    const pie_msg = document.getElementById("pie_empty");
+    if (pie_msg) pie_msg.style.display = empty ? "" : "none";
+    const pie_canvas = document.getElementById("pie_chart");
+    if (pie_canvas) pie_canvas.style.display = empty ? "none" : "";
 }
 
 // ---------------------------------------------------------------------

--- a/src/dashboard/webview/dashboard.js
+++ b/src/dashboard/webview/dashboard.js
@@ -165,7 +165,7 @@ function build_sessions_from_events(events) {
         return stateByJob.get(job);
     }
 
-    function noteSource(state, e) {
+    function note_source(state, e) {
         if (typeof e.global_line_index === "number" && e.global_line_index >= 0) state.hasGlobal = true;
         if (typeof e.workspace_line_index === "number" && e.workspace_line_index >= 0) state.hasWorkspace = true;
     }
@@ -226,7 +226,7 @@ function build_sessions_from_events(events) {
                 state.pausePairs = 0;
                 state.hasGlobal = false;
                 state.hasWorkspace = false;
-                noteSource(state, e);
+                note_source(state, e);
                 break;
             }
 
@@ -235,7 +235,7 @@ function build_sessions_from_events(events) {
                     state.accumulatedMs += ts - state.lastActiveStart;
                     state.lastActiveStart = null;
                     state.inPause = true;
-                    noteSource(state, e);
+                    note_source(state, e);
                 }
                 break;
             }
@@ -245,14 +245,14 @@ function build_sessions_from_events(events) {
                     state.inPause = false;
                     state.lastActiveStart = ts;
                     state.pausePairs += 1;
-                    noteSource(state, e);
+                    note_source(state, e);
                 }
                 break;
             }
 
             case "stop": {
                 if (state.currentSession) {
-                    noteSource(state, e);
+                    note_source(state, e);
                     finalizeSession(job, ts, e.task);
                 }
                 break;
@@ -284,9 +284,9 @@ function assign_job_colors(allSessions) {
         "#8a8a3a", "#b06a9e"
     ];
     // Alphabetical order → a job keeps the same colour across data reloads.
-    const jobs = [...new Set(allSessions.map(s => s.job))].sort((a, b) => a.localeCompare(b));
+    all_jobs_sorted = [...new Set(allSessions.map(s => s.job))].sort((a, b) => a.localeCompare(b));
     job_color_map = {};
-    jobs.forEach((job, i) => {
+    all_jobs_sorted.forEach((job, i) => {
         job_color_map[job] = base[i % base.length];
     });
 }
@@ -295,10 +295,25 @@ function color_for(job) {
     return job_color_map[job] || "#898781";
 }
 
-// Chart chrome tokens (match dashboard.css)
-const CHART_SURFACE = "#1e1e1e";
-const CHART_INK_SECONDARY = "#c3c2b7";
-const CHART_GRIDLINE = "#2c2c2a";
+// Chart chrome tokens: read from the CSS custom properties so the stylesheet
+// stays the single source of truth (literals are the no-CSS fallback).
+function css_token(name, fallback) {
+    const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    return value || fallback;
+}
+const CHART_SURFACE = css_token("--surface", "#1e1e1e");
+const CHART_INK_SECONDARY = css_token("--ink-secondary", "#c3c2b7");
+const CHART_GRIDLINE = css_token("--gridline", "#2c2c2a");
+
+/** Escape a string for interpolation into HTML text or attribute values. */
+function escape_html(value) {
+    return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
 
 // ---------------------------------------------------------------------
 // MAIN FILTER PIPELINE
@@ -326,18 +341,21 @@ function render_date_controls() {
 }
 
 function set_date_inputs(start_day, end_day) {
-    const startEl = document.getElementById("start_date");
-    const endEl = document.getElementById("end_date");
-    if (startEl) startEl.value = start_day || "";
-    if (endEl) endEl.value = end_day || "";
+    const start_el = document.getElementById("start_date");
+    const end_el = document.getElementById("end_date");
+    if (start_el) start_el.value = start_day || "";
+    if (end_el) end_el.value = end_day || "";
 }
 
 // ---------------------------------------------------------------------
 // JOB LEGEND + TABLE DROPDOWN (two synced surfaces, one selection)
 // ---------------------------------------------------------------------
 
+// Cached by load_payload — the job list only changes when the payload does.
+let all_jobs_sorted = [];
+
 function all_job_names() {
-    return [...new Set(all_sessions.map(s => s.job))].sort((a, b) => a.localeCompare(b));
+    return all_jobs_sorted;
 }
 
 /** Which jobs are currently selected (state.jobs === null means all). */
@@ -352,49 +370,59 @@ function render_filter_controls() {
     sync_range_inputs();
 }
 
-function render_job_legend() {
-    const container = document.getElementById("job_legend");
+// The legend and the table dropdown are the same picker rendered into two
+// surfaces; only ids/classes/decoration differ.
+const JOB_PICKER_SURFACES = [
+    {
+        container_id: "job_legend",
+        all_id: "job_all_checkbox",
+        row_class: "legend-row",
+        all_row_class: "legend-row legend-all",
+        box_class: "legend-job-box",
+        swatches: true,
+    },
+    {
+        container_id: "job_dropdown_list",
+        all_id: "job_dropdown_all",
+        row_class: "dropdown-row",
+        all_row_class: "dropdown-row",
+        box_class: "dropdown-job-box",
+        swatches: false,
+    },
+];
+
+function job_picker_row(surface, job, checked) {
+    const swatch = surface.swatches
+        ? (job === null
+            ? `<span class="legend-swatch" style="visibility:hidden;"></span>`
+            : `<span class="legend-swatch" style="background:${color_for(job)};"></span>`)
+        : "";
+    const input = job === null
+        ? `<input type="checkbox" id="${surface.all_id}" ${checked ? "checked" : ""}>`
+        : `<input type="checkbox" class="${surface.box_class}" value="${escape_html(job)}" ${checked ? "checked" : ""}>`;
+    const text = job === null ? "All" : escape_html(job);
+    const row_class = job === null ? surface.all_row_class : surface.row_class;
+    return `<label class="${row_class}">${input}${swatch}<span class="legend-text">${text}</span></label>`;
+}
+
+function render_job_picker(surface) {
+    const container = document.getElementById(surface.container_id);
     if (!container) return;
     const selected = selected_job_set();
     const jobs = all_job_names();
-    const allChecked = jobs.every(j => selected.has(j));
+    const all_checked = jobs.every(j => selected.has(j));
 
-    let html =
-        `<label class="legend-row legend-all">` +
-        `<input type="checkbox" id="job_all_checkbox" ${allChecked ? "checked" : ""}>` +
-        `<span class="legend-swatch" style="visibility:hidden;"></span>` +
-        `<span class="legend-text">All</span></label>`;
+    container.innerHTML =
+        job_picker_row(surface, null, all_checked) +
+        jobs.map(job => job_picker_row(surface, job, selected.has(job))).join("");
+}
 
-    jobs.forEach(job => {
-        const checked = selected.has(job) ? "checked" : "";
-        html +=
-            `<label class="legend-row">` +
-            `<input type="checkbox" class="legend-job-box" value="${job}" ${checked}>` +
-            `<span class="legend-swatch" style="background:${color_for(job)};"></span>` +
-            `<span class="legend-text">${job}</span></label>`;
-    });
-
-    container.innerHTML = html;
+function render_job_legend() {
+    render_job_picker(JOB_PICKER_SURFACES[0]);
 }
 
 function render_job_dropdown() {
-    const list = document.getElementById("job_dropdown_list");
-    if (!list) return;
-    const selected = selected_job_set();
-    const jobs = all_job_names();
-    const allChecked = jobs.every(j => selected.has(j));
-
-    let html =
-        `<label class="dropdown-row">` +
-        `<input type="checkbox" id="job_dropdown_all" ${allChecked ? "checked" : ""}> All</label>`;
-    jobs.forEach(job => {
-        const checked = selected.has(job) ? "checked" : "";
-        html +=
-            `<label class="dropdown-row">` +
-            `<input type="checkbox" class="dropdown-job-box" value="${job}" ${checked}> ${job}</label>`;
-    });
-    list.innerHTML = html;
-
+    render_job_picker(JOB_PICKER_SURFACES[1]);
     update_dropdown_summary();
 }
 
@@ -414,12 +442,12 @@ function update_dropdown_summary() {
  * Update the shared job selection from one surface, then re-render both.
  * A full set collapses to null so newly appearing jobs stay included.
  */
-function set_job_selection(jobArray) {
+function set_job_selection(job_array) {
     const jobs = all_job_names();
-    if (jobArray.length === jobs.length) {
+    if (job_array.length === jobs.length) {
         filter_state.jobs = null;
     } else {
-        filter_state.jobs = jobArray;
+        filter_state.jobs = job_array;
     }
     render_job_legend();
     render_job_dropdown();
@@ -459,13 +487,28 @@ function attach_filter_listeners() {
     bind_once(document.getElementById("end_date"), "change", on_date_input_change);
     bind_once(document.getElementById("clear_filters_btn"), "click", clear_filters);
 
+    // Debounced: re-filtering destroys/rebuilds both charts, so don't do it
+    // per keystroke while a number is being typed.
     ["dur_min", "dur_max", "pause_min", "pause_max"].forEach(id => {
-        bind_once(document.getElementById(id), "input", on_range_change);
+        bind_once(document.getElementById(id), "input", debounce(on_range_change, 150));
     });
 
     // Job legend + dropdown use event delegation so they survive re-renders.
-    bind_once(document.getElementById("job_legend"), "change", on_legend_change);
-    bind_once(document.getElementById("job_dropdown_list"), "change", on_dropdown_change);
+    JOB_PICKER_SURFACES.forEach(surface => {
+        bind_once(document.getElementById(surface.container_id), "change",
+            (ev) => on_job_picker_change(surface, ev));
+    });
+
+    // Session table: delegated Edit-button handler survives row rebuilds.
+    bind_once(document.getElementById("session_table_body"), "click", (ev) => {
+        const btn = ev.target.closest("button.session-edit-btn");
+        if (!btn) return;
+        open_session_edit_modal({
+            job: btn.dataset.job,
+            start: Number(btn.dataset.start),
+            stop: Number(btn.dataset.stop),
+        });
+    });
 
     // Sortable headers
     document.querySelectorAll("#session_table th.sortable").forEach(th => {
@@ -478,6 +521,14 @@ function bind_once(el, evt, handler) {
         el.addEventListener(evt, handler);
         el.dataset.bound = "true";
     }
+}
+
+function debounce(fn, wait_ms) {
+    let timer = null;
+    return function (...args) {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => { timer = null; fn.apply(this, args); }, wait_ms);
+    };
 }
 
 function on_preset_change() {
@@ -520,25 +571,14 @@ function on_range_change() {
     apply_and_render();
 }
 
-function on_legend_change(ev) {
+function on_job_picker_change(surface, ev) {
     const target = ev.target;
-    if (target.id === "job_all_checkbox") {
-        set_job_selection(target.checked ? all_job_names() : []);
+    if (target.id === surface.all_id) {
+        set_job_selection(target.checked ? all_job_names().slice() : []);
         return;
     }
-    if (target.classList.contains("legend-job-box")) {
-        set_job_selection(read_checked_values("#job_legend .legend-job-box"));
-    }
-}
-
-function on_dropdown_change(ev) {
-    const target = ev.target;
-    if (target.id === "job_dropdown_all") {
-        set_job_selection(target.checked ? all_job_names() : []);
-        return;
-    }
-    if (target.classList.contains("dropdown-job-box")) {
-        set_job_selection(read_checked_values("#job_dropdown_list .dropdown-job-box"));
+    if (target.classList.contains(surface.box_class)) {
+        set_job_selection(read_checked_values(`#${surface.container_id} .${surface.box_class}`));
     }
 }
 
@@ -775,7 +815,7 @@ function open_session_edit_modal(session) {
         row.innerHTML = `
             <div class="e-label">${e.event}</div>
             <div class="e-ts"><input type="datetime-local" data-idx="${idx}"></div>
-            <div class="e-task"><input type="text" data-idx="${idx}" value="${e.event === 'stop' ? (e.task || '') : ''}"></div>
+            <div class="e-task"><input type="text" data-idx="${idx}" value="${escape_html(e.event === 'stop' ? (e.task || '') : '')}"></div>
         `;
 
         // store metadata on row for save
@@ -873,37 +913,24 @@ function render_session_table(sessions) {
         const start_local = new Date(s.start).toLocaleString();
         const stop_local = new Date(s.stop).toLocaleString();
 
-        const editBtn = `<button class="session-edit-btn" data-job="${s.job}" data-start="${s.start}" data-stop="${s.stop}">Edit</button>`;
+        const editBtn = `<button class="session-edit-btn" data-job="${escape_html(s.job)}" data-start="${s.start}" data-stop="${s.stop}">Edit</button>`;
 
         tr.dataset.job = s.job;
         tr.dataset.day = day;
 
         tr.innerHTML =
             `<td>${day}</td>` +
-            `<td>${s.job}</td>` +
+            `<td>${escape_html(s.job)}</td>` +
             `<td>${(s.duration_ms / 3600000).toFixed(2)}h</td>` +
-            `<td>${s.task || ""}</td>` +
-            `<td>${start_local}</td>` +
-            `<td>${stop_local}</td>` +
+            `<td>${escape_html(s.task || "")}</td>` +
+            `<td>${escape_html(start_local)}</td>` +
+            `<td>${escape_html(stop_local)}</td>` +
             `<td>${s.pause_pairs}</td>` +
             `<td>${editBtn}</td>`;
 
         body.appendChild(tr);
     });
-
-    // Attach session edit handlers
-    document.querySelectorAll("button.session-edit-btn").forEach(btn => {
-        if (!btn.dataset.bound) {
-            btn.addEventListener('click', (ev) => {
-                const el = ev.currentTarget;
-                const job = el.getAttribute('data-job');
-                const start = Number(el.getAttribute('data-start'));
-                const stop = Number(el.getAttribute('data-stop'));
-                open_session_edit_modal({ job, start, stop });
-            });
-            btn.dataset.bound = 'true';
-        }
-    });
+    // Edit clicks are handled by the delegated listener on #session_table_body
 }
 
 // ---------------------------------------------------------------------

--- a/src/dashboard/webview/filter_state.js
+++ b/src/dashboard/webview/filter_state.js
@@ -1,0 +1,142 @@
+/**
+ * Pure filter/sort logic for the summary dashboard.
+ *
+ * Vanilla JS on purpose: the webview loads it as a plain <script> (global
+ * `TimeScopeFilters`), and the pure-Node test suite require()s the same file.
+ * No DOM access, no Chart.js — dashboard.js owns all rendering.
+ *
+ * The filter state is one plain object; `start_day`/`end_day` are always the
+ * authoritative date bounds (presets resolve into them), `jobs === null`
+ * means "all jobs", and `source` is the issue #3 local/global seam.
+ */
+(function (root, factory) {
+    if (typeof module === "object" && module.exports) {
+        module.exports = factory();
+    } else {
+        root.TimeScopeFilters = factory();
+    }
+})(typeof self !== "undefined" ? self : this, function () {
+    "use strict";
+
+    // Tolerance for hour-entered bounds: 0.1h * 3600000 is not exact in
+    // IEEE754, and the ranges are inclusive by spec.
+    const HOURS_EPSILON = 1e-9;
+
+    function get_local_day(timestamp) {
+        const d = new Date(timestamp);
+        const year = d.getFullYear();
+        const month = String(d.getMonth() + 1).padStart(2, "0");
+        const day = String(d.getDate()).padStart(2, "0");
+        return `${year}-${month}-${day}`;
+    }
+
+    function resolve_preset_range(preset, now) {
+        const today = get_local_day(now.getTime());
+
+        switch (preset) {
+            case "today":
+                return { start_day: today, end_day: today };
+            case "this_week": {
+                const monday = new Date(now);
+                monday.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+                return { start_day: get_local_day(monday.getTime()), end_day: today };
+            }
+            case "last_7": {
+                const d = new Date(now);
+                d.setDate(now.getDate() - 6);
+                return { start_day: get_local_day(d.getTime()), end_day: today };
+            }
+            case "last_14": {
+                const d = new Date(now);
+                d.setDate(now.getDate() - 13);
+                return { start_day: get_local_day(d.getTime()), end_day: today };
+            }
+            case "this_month": {
+                const first = new Date(now.getFullYear(), now.getMonth(), 1);
+                return { start_day: get_local_day(first.getTime()), end_day: today };
+            }
+            case "last_3_months": {
+                const first = new Date(now.getFullYear(), now.getMonth() - 2, 1);
+                return { start_day: get_local_day(first.getTime()), end_day: today };
+            }
+            case "last_year": {
+                const first = new Date(now.getFullYear(), now.getMonth() - 11, 1);
+                return { start_day: get_local_day(first.getTime()), end_day: today };
+            }
+            case "all":
+            case "custom":
+            default:
+                return { start_day: null, end_day: null };
+        }
+    }
+
+    function create_default_filter_state(now) {
+        const range = resolve_preset_range("last_14", now);
+        return {
+            preset: "last_14",
+            start_day: range.start_day,
+            end_day: range.end_day,
+            jobs: null,
+            duration_min_h: null,
+            duration_max_h: null,
+            pauses_min: null,
+            pauses_max: null,
+            source: "merged",
+            sort_key: "start",
+            sort_dir: "desc",
+        };
+    }
+
+    function session_passes(session, state) {
+        const day = get_local_day(session.start);
+        if (state.start_day !== null && day < state.start_day) return false;
+        if (state.end_day !== null && day > state.end_day) return false;
+
+        if (state.jobs !== null && state.jobs.indexOf(session.job) === -1) return false;
+
+        const duration_h = session.duration_ms / 3600000;
+        if (state.duration_min_h !== null && duration_h < state.duration_min_h - HOURS_EPSILON) return false;
+        if (state.duration_max_h !== null && duration_h > state.duration_max_h + HOURS_EPSILON) return false;
+
+        if (state.pauses_min !== null && session.pause_pairs < state.pauses_min) return false;
+        if (state.pauses_max !== null && session.pause_pairs > state.pauses_max) return false;
+
+        if (state.source === "global" && !session.has_global) return false;
+        if (state.source === "workspace" && !session.has_workspace) return false;
+
+        return true;
+    }
+
+    function apply_filters(sessions, state) {
+        return sessions.filter((s) => session_passes(s, state));
+    }
+
+    const SORT_ACCESSORS = {
+        date: (s) => s.start,
+        start: (s) => s.start,
+        stop: (s) => s.stop,
+        duration: (s) => s.duration_ms,
+        pauses: (s) => s.pause_pairs,
+        job: (s) => s.job.toLowerCase(),
+    };
+
+    function sort_sessions(sessions, sort_key, sort_dir) {
+        const accessor = SORT_ACCESSORS[sort_key] || SORT_ACCESSORS.start;
+        const sign = sort_dir === "asc" ? 1 : -1;
+        return sessions.slice().sort((a, b) => {
+            const va = accessor(a);
+            const vb = accessor(b);
+            if (va < vb) return -1 * sign;
+            if (va > vb) return 1 * sign;
+            return 0;
+        });
+    }
+
+    return {
+        create_default_filter_state,
+        resolve_preset_range,
+        apply_filters,
+        sort_sessions,
+        get_local_day,
+    };
+});

--- a/src/dashboard/webview/filter_state.js
+++ b/src/dashboard/webview/filter_state.js
@@ -51,6 +51,11 @@
                 d.setDate(now.getDate() - 13);
                 return { start_day: get_local_day(d.getTime()), end_day: today };
             }
+            case "last_4_weeks": {
+                const d = new Date(now);
+                d.setDate(now.getDate() - 27);
+                return { start_day: get_local_day(d.getTime()), end_day: today };
+            }
             case "this_month": {
                 const first = new Date(now.getFullYear(), now.getMonth(), 1);
                 return { start_day: get_local_day(first.getTime()), end_day: today };

--- a/src/dashboard/webview/filter_state.js
+++ b/src/dashboard/webview/filter_state.js
@@ -76,9 +76,9 @@
     }
 
     function create_default_filter_state(now) {
-        const range = resolve_preset_range("last_14", now);
+        const range = resolve_preset_range("last_4_weeks", now);
         return {
-            preset: "last_14",
+            preset: "last_4_weeks",
             start_day: range.start_day,
             end_day: range.end_day,
             jobs: null,

--- a/src/dashboard/webview/index.html
+++ b/src/dashboard/webview/index.html
@@ -19,65 +19,103 @@
 <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels" nonce="${nonce}"></script>
 
 <link rel="stylesheet" href="${cssUri}">
+<script nonce="${nonce}" src="${filterStateUri}"></script>
 <script nonce="${nonce}" src="${jsUri}"></script>
 
 </head>
 
 <body>
-<div id="sidebar">
-    <h3>Filters</h3>
 
-    <div class="section">
-        <label>Date Range</label>
+<header id="dashboard_header">
+    <h2>Summary Dashboard</h2>
+    <div id="build_info_footer" class="build-info"></div>
+</header>
+
+<!-- Global date filter: applies to every chart and the table -->
+<div id="date_bar">
+    <div class="date-field">
+        <label for="preset_range">Date</label>
         <select id="preset_range">
             <option value="today">Today</option>
             <option value="this_week">This Week</option>
             <option value="last_7">Last 7 Days</option>
+            <option value="last_14">Last 14 Days</option>
             <option value="this_month">This Month</option>
             <option value="last_3_months">Last 3 Months</option>
-            <option value="custom">Custom Range…</option>
+            <option value="last_year">Last Year</option>
+            <option value="all">All</option>
+            <option value="custom">Custom…</option>
         </select>
     </div>
-
-    <div class="section">
-        <label>Jobs</label>
-        <div id="job_filter_container"></div>
+    <div class="date-field">
+        <label for="start_date">Start</label>
+        <input type="date" id="start_date">
     </div>
-
-    <button id="clear_filters_btn" class="sidebar-button">Clear Filters</button>
-
-    <div id="build_info_footer" class="build-info-footer"></div>
+    <div class="date-field">
+        <label for="end_date">End</label>
+        <input type="date" id="end_date">
+    </div>
+    <button id="clear_filters_btn" class="reset-button">Reset filters</button>
 </div>
 
 <div id="main">
-    <h2>Summary Dashboard</h2>
 
-    <div class="chart-container">
-        <h3>Time per Job (Pie Chart)</h3>
-        <canvas id="pie_chart"></canvas>
+    <div class="chart-container pie-section">
+        <h3>Time per Job</h3>
+        <div class="pie-layout">
+            <div id="job_legend" class="job-legend"></div>
+            <div class="pie-canvas-wrap">
+                <canvas id="pie_chart"></canvas>
+            </div>
+        </div>
     </div>
 
     <div class="chart-container">
-        <h3>Time per Job per Day (Stacked Bar)</h3>
+        <h3>Time per Job per Day</h3>
         <canvas id="stacked_bar_chart"></canvas>
     </div>
 
     <div class="chart-container">
         <h3>Raw Sessions</h3>
+
+        <div id="session_filter_row">
+            <div class="filter-field job-filter">
+                <label>Job</label>
+                <details id="job_dropdown" class="job-dropdown">
+                    <summary id="job_dropdown_summary">All jobs</summary>
+                    <div id="job_dropdown_list" class="job-dropdown-list"></div>
+                </details>
+            </div>
+            <div class="filter-field">
+                <label>Duration (h)</label>
+                <input type="number" id="dur_min" min="0" step="0.25" placeholder="min">
+                <span class="range-sep">–</span>
+                <input type="number" id="dur_max" min="0" step="0.25" placeholder="max">
+            </div>
+            <div class="filter-field">
+                <label>Pauses</label>
+                <input type="number" id="pause_min" min="0" step="1" placeholder="min">
+                <span class="range-sep">–</span>
+                <input type="number" id="pause_max" min="0" step="1" placeholder="max">
+            </div>
+        </div>
+
         <table id="session_table">
             <thead>
                 <tr>
-                    <th>Date</th>
-                    <th>Job</th>
-                    <th>Duration</th>
+                    <th class="sortable" data-sort="date">Date</th>
+                    <th class="sortable" data-sort="job">Job</th>
+                    <th class="sortable" data-sort="duration">Duration</th>
                     <th>Task</th>
-                    <th>Start</th>
-                    <th>Stop</th>
-                    <th>Pause/Resume</th>
+                    <th class="sortable" data-sort="start">Start</th>
+                    <th class="sortable" data-sort="stop">Stop</th>
+                    <th class="sortable" data-sort="pauses">Pause/Resume</th>
                     <th>Edit</th>
                 </tr>
+            </thead>
             <tbody id="session_table_body"></tbody>
         </table>
+        <div id="empty_state" class="empty-state" style="display:none;">No sessions match the current filters</div>
     </div>
 
 

--- a/src/dashboard/webview/index.html
+++ b/src/dashboard/webview/index.html
@@ -66,6 +66,10 @@
         <div class="pie-layout">
             <div id="job_legend" class="job-legend"></div>
             <div class="pie-canvas-wrap">
+                <div id="pie_empty" class="pie-empty" style="display:none;">
+                    No data in the selected date range or filters
+                    <span class="pie-empty-hint">The date range may be too narrow — try a wider preset or clear the filters.</span>
+                </div>
                 <canvas id="pie_chart"></canvas>
             </div>
         </div>
@@ -94,7 +98,7 @@
                         </details>
                     </th>
                     <th class="sortable" data-sort="duration">
-                        <span class="th-label">Duration</span>
+                        <span class="th-label"><span class="th-full">Duration</span><span class="th-short">Dur.</span></span>
                         <details class="col-filter">
                             <summary id="dur_filter_toggle" title="Filter by duration"><svg class="funnel" viewBox="0 0 14 14" width="12" height="12" aria-hidden="true"><path d="M1 1h12L8.5 6.5V12l-3 1.5v-7z" fill="currentColor"/></svg></summary>
                             <div class="col-filter-menu range-menu">
@@ -108,7 +112,7 @@
                     <th class="sortable" data-sort="start"><span class="th-label">Start</span></th>
                     <th class="sortable" data-sort="stop"><span class="th-label">Stop</span></th>
                     <th class="sortable" data-sort="pauses">
-                        <span class="th-label">Pause/Resume</span>
+                        <span class="th-label"><span class="th-full">Pause/Resume</span><span class="th-short">P/R</span></span>
                         <details class="col-filter">
                             <summary id="pause_filter_toggle" title="Filter by pause count"><svg class="funnel" viewBox="0 0 14 14" width="12" height="12" aria-hidden="true"><path d="M1 1h12L8.5 6.5V12l-3 1.5v-7z" fill="currentColor"/></svg></summary>
                             <div class="col-filter-menu range-menu">

--- a/src/dashboard/webview/index.html
+++ b/src/dashboard/webview/index.html
@@ -76,41 +76,43 @@
     </div>
 
     <div class="chart-container">
-        <h3>Raw Sessions</h3>
-
-        <div id="session_filter_row">
-            <div class="filter-field job-filter">
-                <label>Job</label>
-                <details id="job_dropdown" class="job-dropdown">
-                    <summary id="job_dropdown_summary">All jobs</summary>
-                    <div id="job_dropdown_list" class="job-dropdown-list"></div>
-                </details>
-            </div>
-            <div class="filter-field">
-                <label>Duration (h)</label>
-                <input type="number" id="dur_min" min="0" step="0.25" placeholder="min">
-                <span class="range-sep">–</span>
-                <input type="number" id="dur_max" min="0" step="0.25" placeholder="max">
-            </div>
-            <div class="filter-field">
-                <label>Pauses</label>
-                <input type="number" id="pause_min" min="0" step="1" placeholder="min">
-                <span class="range-sep">–</span>
-                <input type="number" id="pause_max" min="0" step="1" placeholder="max">
-            </div>
-        </div>
+        <h3>Session Log</h3>
 
         <table id="session_table">
             <thead>
                 <tr>
-                    <th class="sortable" data-sort="date">Date</th>
-                    <th class="sortable" data-sort="job">Job</th>
-                    <th class="sortable" data-sort="duration">Duration</th>
-                    <th>Task</th>
-                    <th class="sortable" data-sort="start">Start</th>
-                    <th class="sortable" data-sort="stop">Stop</th>
-                    <th class="sortable" data-sort="pauses">Pause/Resume</th>
-                    <th>Edit</th>
+                    <th class="sortable" data-sort="date"><span class="th-label">Date</span></th>
+                    <th class="sortable" data-sort="job">
+                        <span class="th-label">Job</span>
+                        <details class="col-filter">
+                            <summary id="job_filter_toggle" title="Filter by job"><svg class="funnel" viewBox="0 0 14 14" width="12" height="12" aria-hidden="true"><path d="M1 1h12L8.5 6.5V12l-3 1.5v-7z" fill="currentColor"/></svg></summary>
+                            <div class="col-filter-menu" id="job_dropdown_list"></div>
+                        </details>
+                    </th>
+                    <th class="sortable" data-sort="duration">
+                        <span class="th-label">Duration</span>
+                        <details class="col-filter">
+                            <summary id="dur_filter_toggle" title="Filter by duration"><svg class="funnel" viewBox="0 0 14 14" width="12" height="12" aria-hidden="true"><path d="M1 1h12L8.5 6.5V12l-3 1.5v-7z" fill="currentColor"/></svg></summary>
+                            <div class="col-filter-menu range-menu">
+                                <label>Min <input type="number" id="dur_min" min="0" step="0.25" placeholder="hours"></label>
+                                <label>Max <input type="number" id="dur_max" min="0" step="0.25" placeholder="hours"></label>
+                            </div>
+                        </details>
+                    </th>
+                    <th><span class="th-label">Task</span></th>
+                    <th class="sortable" data-sort="start"><span class="th-label">Start</span></th>
+                    <th class="sortable" data-sort="stop"><span class="th-label">Stop</span></th>
+                    <th class="sortable" data-sort="pauses">
+                        <span class="th-label">Pause/Resume</span>
+                        <details class="col-filter">
+                            <summary id="pause_filter_toggle" title="Filter by pause count"><svg class="funnel" viewBox="0 0 14 14" width="12" height="12" aria-hidden="true"><path d="M1 1h12L8.5 6.5V12l-3 1.5v-7z" fill="currentColor"/></svg></summary>
+                            <div class="col-filter-menu range-menu">
+                                <label>Min <input type="number" id="pause_min" min="0" step="1" placeholder="count"></label>
+                                <label>Max <input type="number" id="pause_max" min="0" step="1" placeholder="count"></label>
+                            </div>
+                        </details>
+                    </th>
+                    <th><span class="th-label">Edit</span></th>
                 </tr>
             </thead>
             <tbody id="session_table_body"></tbody>

--- a/src/dashboard/webview/index.html
+++ b/src/dashboard/webview/index.html
@@ -40,6 +40,7 @@
             <option value="this_week">This Week</option>
             <option value="last_7">Last 7 Days</option>
             <option value="last_14">Last 14 Days</option>
+            <option value="last_4_weeks">Last 4 Weeks</option>
             <option value="this_month">This Month</option>
             <option value="last_3_months">Last 3 Months</option>
             <option value="last_year">Last Year</option>

--- a/src/dashboard/webview/index.html
+++ b/src/dashboard/webview/index.html
@@ -112,7 +112,7 @@
                     <th class="sortable" data-sort="start"><span class="th-label">Start</span></th>
                     <th class="sortable" data-sort="stop"><span class="th-label">Stop</span></th>
                     <th class="sortable" data-sort="pauses">
-                        <span class="th-label"><span class="th-full">Pause/Resume</span><span class="th-short">P/R</span></span>
+                        <span class="th-label" title="Pause/Resume">P/R</span>
                         <details class="col-filter">
                             <summary id="pause_filter_toggle" title="Filter by pause count"><svg class="funnel" viewBox="0 0 14 14" width="12" height="12" aria-hidden="true"><path d="M1 1h12L8.5 6.5V12l-3 1.5v-7z" fill="currentColor"/></svg></summary>
                             <div class="col-filter-menu range-menu">

--- a/src/dashboard/webview/index.html
+++ b/src/dashboard/webview/index.html
@@ -87,7 +87,10 @@
                         <span class="th-label">Job</span>
                         <details class="col-filter">
                             <summary id="job_filter_toggle" title="Filter by job"><svg class="funnel" viewBox="0 0 14 14" width="12" height="12" aria-hidden="true"><path d="M1 1h12L8.5 6.5V12l-3 1.5v-7z" fill="currentColor"/></svg></summary>
-                            <div class="col-filter-menu" id="job_dropdown_list"></div>
+                            <div class="col-filter-menu">
+                                <div id="job_dropdown_list"></div>
+                                <button type="button" class="menu-clear" id="job_filter_clear">Clear</button>
+                            </div>
                         </details>
                     </th>
                     <th class="sortable" data-sort="duration">
@@ -97,6 +100,7 @@
                             <div class="col-filter-menu range-menu">
                                 <label>Min <input type="number" id="dur_min" min="0" step="0.25" placeholder="hours"></label>
                                 <label>Max <input type="number" id="dur_max" min="0" step="0.25" placeholder="hours"></label>
+                                <button type="button" class="menu-clear" id="dur_filter_clear">Clear</button>
                             </div>
                         </details>
                     </th>
@@ -110,6 +114,7 @@
                             <div class="col-filter-menu range-menu">
                                 <label>Min <input type="number" id="pause_min" min="0" step="1" placeholder="count"></label>
                                 <label>Max <input type="number" id="pause_max" min="0" step="1" placeholder="count"></label>
+                                <button type="button" class="menu-clear" id="pause_filter_clear">Clear</button>
                             </div>
                         </details>
                     </th>

--- a/src/test/run_tests.ts
+++ b/src/test/run_tests.ts
@@ -9,6 +9,7 @@ import { run_job_domain_tests } from "./test_job";
 import { run_job_collection_tests } from "./test_job_collection";
 import { run_build_info_tests } from "./test_build_info";
 import { run_resolve_storage_dir_tests } from "./test_paths";
+import { run_filter_state_tests } from "./test_filter_state";
 
 async function main() {
     try {
@@ -35,6 +36,7 @@ async function main() {
         run_dashboard_editRoundTrip_tests();
         run_build_info_tests();
         run_resolve_storage_dir_tests();
+        run_filter_state_tests();
         console.log("All tests passed.");
         process.exit(0);
     } catch (err) {

--- a/src/test/test_filter_state.ts
+++ b/src/test/test_filter_state.ts
@@ -1,0 +1,443 @@
+import * as path from "path";
+import * as assert from "assert";
+
+// ---------------------------------------------------------------------------
+// Typed view of the plain-JS webview module (src/dashboard/webview/filter_state.js).
+// The module is vanilla JS so the webview can load it without a build step;
+// tests require() it directly from source and cast to this interface.
+// ---------------------------------------------------------------------------
+
+interface FilterState {
+    preset: string;
+    start_day: string | null;
+    end_day: string | null;
+    jobs: string[] | null;
+    duration_min_h: number | null;
+    duration_max_h: number | null;
+    pauses_min: number | null;
+    pauses_max: number | null;
+    source: "merged" | "global" | "workspace";
+    sort_key: string;
+    sort_dir: "asc" | "desc";
+}
+
+interface FilterSession {
+    job: string;
+    start: number;
+    stop: number;
+    duration_ms: number;
+    task: string;
+    pause_pairs: number;
+    has_global: boolean;
+    has_workspace: boolean;
+}
+
+interface PresetRange {
+    start_day: string | null;
+    end_day: string | null;
+}
+
+interface FilterStateModule {
+    create_default_filter_state(now: Date): FilterState;
+    resolve_preset_range(preset: string, now: Date): PresetRange;
+    apply_filters(sessions: FilterSession[], state: FilterState): FilterSession[];
+    sort_sessions(sessions: FilterSession[], sort_key: string, sort_dir: "asc" | "desc"): FilterSession[];
+    get_local_day(timestamp: number): string;
+}
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs_module = require(
+    path.join(__dirname, "..", "..", "src", "dashboard", "webview", "filter_state.js")
+) as FilterStateModule;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Fixed "now": Wednesday 2026-07-15, 12:00 local. */
+function fixed_now(): Date {
+    return new Date(2026, 6, 15, 12, 0, 0, 0);
+}
+
+/** Timestamp for a local calendar day at a given hour. */
+function ts(year: number, month1: number, day: number, hour = 10): number {
+    return new Date(year, month1 - 1, day, hour, 0, 0, 0).getTime();
+}
+
+let session_seq = 0;
+function make_session(overrides: Partial<FilterSession>): FilterSession {
+    session_seq += 1;
+    const start = overrides.start ?? ts(2026, 7, 10);
+    const duration_ms = overrides.duration_ms ?? 3600_000;
+    return {
+        job: "Alpha",
+        start,
+        stop: start + duration_ms,
+        duration_ms,
+        task: `task-${session_seq}`,
+        pause_pairs: 0,
+        has_global: true,
+        has_workspace: true,
+        ...overrides,
+    };
+}
+
+function hours(h: number): number {
+    return Math.round(h * 3600_000);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// create_default_filter_state
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Tests the default filter state:
+ * - Target: create_default_filter_state in src/dashboard/webview/filter_state.js
+ * - What: the state the dashboard applies on first render.
+ * - Why: issue #5 requires "Last 14 Days" as the default AND actually applied
+ *   on load (bug #31 was the old "Today" default never being applied). The
+ *   resolved start/end days make the default self-applying.
+ */
+export function run_default_filter_state_tests(): void {
+    const state = fs_module.create_default_filter_state(fixed_now());
+
+    assert.strictEqual(state.preset, "last_14", "default preset is Last 14 Days");
+    assert.strictEqual(state.start_day, "2026-07-02", "start day resolved: 13 days before now");
+    assert.strictEqual(state.end_day, "2026-07-15", "end day resolved: today");
+    assert.strictEqual(state.jobs, null, "null jobs = all jobs (new jobs stay included)");
+    assert.strictEqual(state.duration_min_h, null);
+    assert.strictEqual(state.duration_max_h, null);
+    assert.strictEqual(state.pauses_min, null);
+    assert.strictEqual(state.pauses_max, null);
+    assert.strictEqual(state.source, "merged", "issue #3 seam defaults to merged view");
+    assert.strictEqual(state.sort_key, "start", "default sort: newest first");
+    assert.strictEqual(state.sort_dir, "desc");
+
+    console.log("  ✓ default filter state tests passed");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// resolve_preset_range
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Tests preset → local-day range resolution:
+ * - Target: resolve_preset_range in filter_state.js
+ * - What: every quick-select preset resolves to an inclusive local-day range
+ *   relative to an injected "now"; all/custom resolve to unbounded.
+ * - Why: this is the heart of the date filter; boundary math must be exact
+ *   (off-by-one here silently hides or leaks sessions at range edges).
+ */
+export function run_resolve_preset_range_tests(): void {
+    const now = fixed_now(); // Wednesday 2026-07-15
+
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("today", now),
+        { start_day: "2026-07-15", end_day: "2026-07-15" });
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("this_week", now),
+        { start_day: "2026-07-13", end_day: "2026-07-15" }, "week starts Monday");
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("last_7", now),
+        { start_day: "2026-07-09", end_day: "2026-07-15" }, "7 days inclusive of today");
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("last_14", now),
+        { start_day: "2026-07-02", end_day: "2026-07-15" }, "14 days inclusive of today");
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("this_month", now),
+        { start_day: "2026-07-01", end_day: "2026-07-15" });
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("last_3_months", now),
+        { start_day: "2026-05-01", end_day: "2026-07-15" }, "first of month two months back");
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("last_year", now),
+        { start_day: "2025-08-01", end_day: "2026-07-15" }, "first of month eleven months back");
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("all", now),
+        { start_day: null, end_day: null }, "all = unbounded");
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("custom", now),
+        { start_day: null, end_day: null }, "custom = caller-managed fields");
+
+    // Sunday: this_week must reach back to the previous Monday
+    const sunday = new Date(2026, 6, 19, 12, 0, 0, 0);
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("this_week", sunday),
+        { start_day: "2026-07-13", end_day: "2026-07-19" });
+
+    // Monday: this_week starts today
+    const monday = new Date(2026, 6, 13, 12, 0, 0, 0);
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("this_week", monday),
+        { start_day: "2026-07-13", end_day: "2026-07-13" });
+
+    // Year boundary: last_14 from early January crosses into the previous year
+    const january = new Date(2026, 0, 5, 12, 0, 0, 0);
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("last_14", january),
+        { start_day: "2025-12-23", end_day: "2026-01-05" });
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("last_3_months", january),
+        { start_day: "2025-11-01", end_day: "2026-01-05" });
+
+    console.log("  ✓ resolve_preset_range tests passed");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// apply_filters — one dimension at a time
+// ═══════════════════════════════════════════════════════════════════════════
+
+function state_with(overrides: Partial<FilterState>): FilterState {
+    const base = fs_module.create_default_filter_state(fixed_now());
+    return { ...base, start_day: null, end_day: null, ...overrides };
+}
+
+/**
+ * Tests date-range filtering:
+ * - What: sessions are kept when the local day of their start falls inside
+ *   [start_day, end_day], boundaries inclusive; null bounds are open-ended.
+ * - Why: issue #5's presets and manual start/end fields both reduce to this
+ *   comparison; boundary days must be included, matching the old sidebar.
+ */
+export function run_apply_filters_date_tests(): void {
+    const sessions = [
+        make_session({ job: "Edge-start", start: ts(2026, 7, 2) }),
+        make_session({ job: "Inside", start: ts(2026, 7, 10) }),
+        make_session({ job: "Edge-end", start: ts(2026, 7, 15) }),
+        make_session({ job: "Before", start: ts(2026, 7, 1) }),
+        make_session({ job: "After", start: ts(2026, 7, 16) }),
+    ];
+
+    const bounded = fs_module.apply_filters(sessions, state_with({ start_day: "2026-07-02", end_day: "2026-07-15" }));
+    assert.deepStrictEqual(bounded.map(s => s.job), ["Edge-start", "Inside", "Edge-end"], "boundary days are inclusive");
+
+    const open_start = fs_module.apply_filters(sessions, state_with({ start_day: null, end_day: "2026-07-02" }));
+    assert.deepStrictEqual(open_start.map(s => s.job), ["Edge-start", "Before"], "null start = open-ended past");
+
+    const open_end = fs_module.apply_filters(sessions, state_with({ start_day: "2026-07-15", end_day: null }));
+    assert.deepStrictEqual(open_end.map(s => s.job), ["Edge-end", "After"], "null end = open-ended future");
+
+    const unbounded = fs_module.apply_filters(sessions, state_with({}));
+    assert.strictEqual(unbounded.length, 5, "both bounds null = everything");
+
+    console.log("  ✓ apply_filters date tests passed");
+}
+
+/**
+ * Tests job filtering:
+ * - What: jobs === null keeps every job; an array keeps only listed jobs;
+ *   an empty array keeps nothing (all boxes unchecked).
+ * - Why: the legend checkboxes and the table's job dropdown both write this
+ *   one field — its semantics define their shared behavior.
+ */
+export function run_apply_filters_job_tests(): void {
+    const sessions = [
+        make_session({ job: "Alpha" }),
+        make_session({ job: "Beta" }),
+        make_session({ job: "Gamma" }),
+    ];
+
+    assert.strictEqual(fs_module.apply_filters(sessions, state_with({ jobs: null })).length, 3, "null = all jobs");
+    assert.deepStrictEqual(
+        fs_module.apply_filters(sessions, state_with({ jobs: ["Alpha", "Gamma"] })).map(s => s.job),
+        ["Alpha", "Gamma"]);
+    assert.strictEqual(fs_module.apply_filters(sessions, state_with({ jobs: [] })).length, 0, "empty array = nothing");
+
+    console.log("  ✓ apply_filters job tests passed");
+}
+
+/**
+ * Tests duration range filtering:
+ * - What: inclusive "greater than _ and less than _" in hours; null = unbounded.
+ * - Why: issue #5 explicitly requires boundary values to be included, and
+ *   hour→ms conversion invites float error (0.1h is not representable exactly),
+ *   so exact-boundary sessions are the regression risk.
+ */
+export function run_apply_filters_duration_tests(): void {
+    const sessions = [
+        make_session({ job: "Short", duration_ms: hours(0.5) }),
+        make_session({ job: "ExactMin", duration_ms: hours(2) }),
+        make_session({ job: "Mid", duration_ms: hours(3) }),
+        make_session({ job: "ExactMax", duration_ms: hours(4) }),
+        make_session({ job: "Long", duration_ms: hours(8) }),
+    ];
+
+    const both = fs_module.apply_filters(sessions, state_with({ duration_min_h: 2, duration_max_h: 4 }));
+    assert.deepStrictEqual(both.map(s => s.job), ["ExactMin", "Mid", "ExactMax"], "both boundaries inclusive");
+
+    const min_only = fs_module.apply_filters(sessions, state_with({ duration_min_h: 4 }));
+    assert.deepStrictEqual(min_only.map(s => s.job), ["ExactMax", "Long"], "null max = unbounded above");
+
+    const max_only = fs_module.apply_filters(sessions, state_with({ duration_max_h: 0.5 }));
+    assert.deepStrictEqual(max_only.map(s => s.job), ["Short"], "null min = unbounded below");
+
+    // Float-hazard boundary: 0.1h = 360000 ms, but 0.1 * 3600000 ≠ 360000 in IEEE754
+    const tenth = [make_session({ job: "Tenth", duration_ms: 360_000 })];
+    assert.strictEqual(
+        fs_module.apply_filters(tenth, state_with({ duration_min_h: 0.1, duration_max_h: 0.1 })).length,
+        1, "exact 0.1h session survives a [0.1, 0.1] range despite float error");
+
+    console.log("  ✓ apply_filters duration tests passed");
+}
+
+/**
+ * Tests pause/resume range filtering:
+ * - What: inclusive integer range on the session's pause/resume pair count.
+ * - Why: same contract as duration per issue #5 ("same concept as Duration").
+ */
+export function run_apply_filters_pauses_tests(): void {
+    const sessions = [
+        make_session({ job: "None", pause_pairs: 0 }),
+        make_session({ job: "One", pause_pairs: 1 }),
+        make_session({ job: "Three", pause_pairs: 3 }),
+        make_session({ job: "Five", pause_pairs: 5 }),
+    ];
+
+    const both = fs_module.apply_filters(sessions, state_with({ pauses_min: 1, pauses_max: 3 }));
+    assert.deepStrictEqual(both.map(s => s.job), ["One", "Three"], "boundaries inclusive");
+
+    const min_only = fs_module.apply_filters(sessions, state_with({ pauses_min: 3 }));
+    assert.deepStrictEqual(min_only.map(s => s.job), ["Three", "Five"]);
+
+    const max_only = fs_module.apply_filters(sessions, state_with({ pauses_max: 0 }));
+    assert.deepStrictEqual(max_only.map(s => s.job), ["None"], "max 0 keeps pause-free sessions");
+
+    console.log("  ✓ apply_filters pauses tests passed");
+}
+
+/**
+ * Tests source filtering (issue #3 seam):
+ * - What: "merged" keeps everything; "global"/"workspace" keep sessions whose
+ *   events came from that log.
+ * - Why: issue #5's architecture must not lock out issue #3's local/global
+ *   scope selector — this proves the filter model already carries it.
+ */
+export function run_apply_filters_source_tests(): void {
+    const sessions = [
+        make_session({ job: "Both", has_global: true, has_workspace: true }),
+        make_session({ job: "GlobalOnly", has_global: true, has_workspace: false }),
+        make_session({ job: "WorkspaceOnly", has_global: false, has_workspace: true }),
+    ];
+
+    assert.strictEqual(fs_module.apply_filters(sessions, state_with({ source: "merged" })).length, 3);
+    assert.deepStrictEqual(
+        fs_module.apply_filters(sessions, state_with({ source: "global" })).map(s => s.job),
+        ["Both", "GlobalOnly"]);
+    assert.deepStrictEqual(
+        fs_module.apply_filters(sessions, state_with({ source: "workspace" })).map(s => s.job),
+        ["Both", "WorkspaceOnly"]);
+
+    console.log("  ✓ apply_filters source tests passed");
+}
+
+/**
+ * Tests filter composition and purity:
+ * - What: all dimensions AND together; the input array and its sessions are
+ *   never mutated.
+ * - Why: one filtered set must drive charts and table alike (scope decision),
+ *   and the codebase convention is immutability outside Runtime.
+ */
+export function run_apply_filters_combined_tests(): void {
+    const keeper = make_session({ job: "Alpha", start: ts(2026, 7, 10), duration_ms: hours(3), pause_pairs: 2 });
+    const sessions = [
+        keeper,
+        make_session({ job: "Beta", start: ts(2026, 7, 10), duration_ms: hours(3), pause_pairs: 2 }), // wrong job
+        make_session({ job: "Alpha", start: ts(2026, 6, 10), duration_ms: hours(3), pause_pairs: 2 }), // wrong date
+        make_session({ job: "Alpha", start: ts(2026, 7, 10), duration_ms: hours(9), pause_pairs: 2 }), // wrong duration
+        make_session({ job: "Alpha", start: ts(2026, 7, 10), duration_ms: hours(3), pause_pairs: 0 }), // wrong pauses
+    ];
+    const snapshot = JSON.stringify(sessions);
+
+    const result = fs_module.apply_filters(sessions, state_with({
+        start_day: "2026-07-02", end_day: "2026-07-15",
+        jobs: ["Alpha"],
+        duration_min_h: 2, duration_max_h: 4,
+        pauses_min: 1, pauses_max: 3,
+    }));
+
+    assert.strictEqual(result.length, 1, "all dimensions AND together");
+    assert.strictEqual(result[0], keeper, "sessions pass through by reference");
+    assert.strictEqual(JSON.stringify(sessions), snapshot, "input is not mutated");
+
+    console.log("  ✓ apply_filters combined tests passed");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// sort_sessions
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Tests table sorting:
+ * - Target: sort_sessions in filter_state.js
+ * - What: sorts by each sortable column key in either direction, returning a
+ *   new array (input untouched); job names compare case-insensitively.
+ * - Why: issue #5 puts sorting in scope; the table renders whatever order
+ *   this returns, with start-descending as the dashboard default.
+ */
+export function run_sort_sessions_tests(): void {
+    const a = make_session({ job: "beta", start: ts(2026, 7, 10), duration_ms: hours(1), pause_pairs: 2 });
+    const b = make_session({ job: "Alpha", start: ts(2026, 7, 12), duration_ms: hours(3), pause_pairs: 0 });
+    const c = make_session({ job: "Gamma", start: ts(2026, 7, 11), duration_ms: hours(2), pause_pairs: 1 });
+    const sessions = [a, b, c];
+
+    assert.deepStrictEqual(fs_module.sort_sessions(sessions, "start", "desc").map(s => s.job),
+        ["Alpha", "Gamma", "beta"], "start desc = newest first (default)");
+    assert.deepStrictEqual(fs_module.sort_sessions(sessions, "start", "asc").map(s => s.job),
+        ["beta", "Gamma", "Alpha"]);
+    assert.deepStrictEqual(fs_module.sort_sessions(sessions, "stop", "asc").map(s => s.job),
+        ["beta", "Gamma", "Alpha"]);
+    assert.deepStrictEqual(fs_module.sort_sessions(sessions, "duration", "asc").map(s => s.job),
+        ["beta", "Gamma", "Alpha"]);
+    assert.deepStrictEqual(fs_module.sort_sessions(sessions, "pauses", "desc").map(s => s.job),
+        ["beta", "Gamma", "Alpha"]);
+    assert.deepStrictEqual(fs_module.sort_sessions(sessions, "job", "asc").map(s => s.job),
+        ["Alpha", "beta", "Gamma"], "job sort is case-insensitive");
+
+    // "date" (local day column) orders like start
+    assert.deepStrictEqual(fs_module.sort_sessions(sessions, "date", "asc").map(s => s.job),
+        ["beta", "Gamma", "Alpha"]);
+
+    const sorted = fs_module.sort_sessions(sessions, "start", "asc");
+    assert.notStrictEqual(sorted, sessions, "returns a new array");
+    assert.deepStrictEqual(sessions.map(s => s.job), ["beta", "Alpha", "Gamma"], "input order untouched");
+
+    console.log("  ✓ sort_sessions tests passed");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// get_local_day
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Tests local-day formatting:
+ * - What: timestamp → "YYYY-MM-DD" in local time, zero-padded.
+ * - Why: exported so dashboard.js and the date filter share one definition of
+ *   "day" — a UTC/local mismatch here would shift sessions across midnight.
+ */
+export function run_get_local_day_tests(): void {
+    assert.strictEqual(fs_module.get_local_day(ts(2026, 7, 15, 0)), "2026-07-15", "midnight stays on its day");
+    assert.strictEqual(fs_module.get_local_day(ts(2026, 7, 15, 23)), "2026-07-15", "late evening stays on its day");
+    assert.strictEqual(fs_module.get_local_day(ts(2026, 1, 5)), "2026-01-05", "zero-padded month and day");
+
+    console.log("  ✓ get_local_day tests passed");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Exported runner
+// ═══════════════════════════════════════════════════════════════════════════
+
+export function run_filter_state_tests(): void {
+    console.log("filter_state: defaults & presets");
+    run_default_filter_state_tests();
+    run_resolve_preset_range_tests();
+    console.log("filter_state: apply_filters");
+    run_apply_filters_date_tests();
+    run_apply_filters_job_tests();
+    run_apply_filters_duration_tests();
+    run_apply_filters_pauses_tests();
+    run_apply_filters_source_tests();
+    run_apply_filters_combined_tests();
+    console.log("filter_state: sorting & utilities");
+    run_sort_sessions_tests();
+    run_get_local_day_tests();
+}

--- a/src/test/test_filter_state.ts
+++ b/src/test/test_filter_state.ts
@@ -101,8 +101,8 @@ function hours(h: number): number {
 export function run_default_filter_state_tests(): void {
     const state = fs_module.create_default_filter_state(fixed_now());
 
-    assert.strictEqual(state.preset, "last_14", "default preset is Last 14 Days");
-    assert.strictEqual(state.start_day, "2026-07-02", "start day resolved: 13 days before now");
+    assert.strictEqual(state.preset, "last_4_weeks", "default preset is Last 4 Weeks");
+    assert.strictEqual(state.start_day, "2026-06-18", "start day resolved: 27 days before now");
     assert.strictEqual(state.end_day, "2026-07-15", "end day resolved: today");
     assert.strictEqual(state.jobs, null, "null jobs = all jobs (new jobs stay included)");
     assert.strictEqual(state.duration_min_h, null);

--- a/src/test/test_filter_state.ts
+++ b/src/test/test_filter_state.ts
@@ -144,6 +144,9 @@ export function run_resolve_preset_range_tests(): void {
         fs_module.resolve_preset_range("last_14", now),
         { start_day: "2026-07-02", end_day: "2026-07-15" }, "14 days inclusive of today");
     assert.deepStrictEqual(
+        fs_module.resolve_preset_range("last_4_weeks", now),
+        { start_day: "2026-06-18", end_day: "2026-07-15" }, "28 days inclusive of today");
+    assert.deepStrictEqual(
         fs_module.resolve_preset_range("this_month", now),
         { start_day: "2026-07-01", end_day: "2026-07-15" });
     assert.deepStrictEqual(

--- a/src/test/test_filter_state.ts
+++ b/src/test/test_filter_state.ts
@@ -186,6 +186,45 @@ export function run_resolve_preset_range_tests(): void {
     console.log("  ✓ resolve_preset_range tests passed");
 }
 
+/**
+ * Tests preset resolution across DST transitions:
+ * - What: ranges spanning the US spring-forward (2026-03-08) and fall-back
+ *   (2026-11-01) dates resolve to correct calendar days.
+ * - Why: the implementation must use calendar arithmetic (setDate), not
+ *   milliseconds — an N*24h subtraction lands one hour short/long across a
+ *   DST boundary and shifts the range's start to the wrong day in any
+ *   DST-observing timezone. These assertions hold in every timezone but
+ *   would catch an ms-arithmetic regression on DST-observing CI machines.
+ */
+export function run_dst_boundary_tests(): void {
+    // Range spanning spring-forward (2026-03-08): 23h day in DST zones
+    const after_spring = new Date(2026, 2, 12, 12, 0, 0, 0);
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("last_7", after_spring),
+        { start_day: "2026-03-06", end_day: "2026-03-12" }, "last_7 across spring-forward");
+    const mid_march = new Date(2026, 2, 15, 12, 0, 0, 0);
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("last_14", mid_march),
+        { start_day: "2026-03-02", end_day: "2026-03-15" }, "last_14 across spring-forward");
+
+    // Range spanning fall-back (2026-11-01): 25h day in DST zones
+    const after_fall = new Date(2026, 10, 4, 12, 0, 0, 0);
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("last_7", after_fall),
+        { start_day: "2026-10-29", end_day: "2026-11-04" }, "last_7 across fall-back");
+    assert.deepStrictEqual(
+        fs_module.resolve_preset_range("last_4_weeks", after_fall),
+        { start_day: "2026-10-08", end_day: "2026-11-04" }, "last_4_weeks across fall-back");
+
+    // Day bucketing on the transition day itself
+    assert.strictEqual(fs_module.get_local_day(ts(2026, 3, 8, 23)), "2026-03-08",
+        "late evening of the spring-forward day stays on its day");
+    assert.strictEqual(fs_module.get_local_day(ts(2026, 11, 1, 23)), "2026-11-01",
+        "late evening of the fall-back day stays on its day");
+
+    console.log("  ✓ DST boundary tests passed");
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // apply_filters — one dimension at a time
 // ═══════════════════════════════════════════════════════════════════════════
@@ -433,6 +472,7 @@ export function run_filter_state_tests(): void {
     console.log("filter_state: defaults & presets");
     run_default_filter_state_tests();
     run_resolve_preset_range_tests();
+    run_dst_boundary_tests();
     console.log("filter_state: apply_filters");
     run_apply_filters_date_tests();
     run_apply_filters_job_tests();

--- a/tests/webview/dashboard.spec.ts
+++ b/tests/webview/dashboard.spec.ts
@@ -4,7 +4,9 @@ import { build_fixture, FixtureData } from "./fixtures";
 import { open_dashboard, posted_messages, reply, to_datetime_input_value } from "./harness";
 
 // Fixture: Alpha today 09:00–10:30 (1 pause/resume pair), Beta today
-// 13:00–14:00, Alpha 40 days ago 10:00–11:00. Default preset is "today".
+// 13:00–14:00, Alpha 40 days ago 10:00–11:00. Time is frozen at FIXED_NOW,
+// and the default preset (Last 14 Days) is applied on load, so the 40-days-ago
+// session is filtered out until a wider preset is chosen.
 
 interface EditLogEntriesPayload {
     edits: Array<{ id: string; new_record: Record<string, unknown> }>;
@@ -37,27 +39,34 @@ test("loads, requests data, and renders charts, filters, and table", async ({ pa
     const posted = await posted_messages(page);
     expect(posted[0]).toEqual({ type: "request_data" });
 
-    // Job filter: "All" + one checkbox per job, all checked initially
+    // Default preset is Last 14 Days, applied on load (was bug #31)
+    await expect(page.locator("#preset_range")).toHaveValue("last_14");
+
+    // Job legend: "All" + one checkbox per job, all checked initially
     await expect(page.locator("#job_all_checkbox")).toBeChecked();
-    await expect(page.locator("#job_filter_container .job-box")).toHaveCount(2);
-    for (const box of await page.locator("#job_filter_container .job-box").all()) {
+    await expect(page.locator("#job_legend .legend-job-box")).toHaveCount(2);
+    for (const box of await page.locator("#job_legend .legend-job-box").all()) {
         await expect(box).toBeChecked();
     }
 
-    // KNOWN BUG #31: initial render ignores the preset select ("Today") and
-    // shows ALL sessions until a filter control is touched. Update this
-    // assertion (3 → 2 rows) when #31 is fixed.
+    // Default filter applied: the 40-days-ago "old work" session is excluded,
+    // leaving the two "today" sessions (newest first).
     const rows = page.locator("#session_table_body tr");
-    await expect(rows).toHaveCount(3);
+    await expect(rows).toHaveCount(2);
     await expect(rows.nth(0)).toContainText("Beta");
     await expect(rows.nth(1)).toContainText("morning work");
-    await expect(rows.nth(2)).toContainText("old work");
 
     // Charts exist in Chart.js's registry with the rendered data
     const pie_labels = await page.evaluate(() => (window as any).Chart.getChart("pie_chart")?.data.labels);
     expect(pie_labels?.slice().sort()).toEqual(["Alpha", "Beta"]);
     const has_bar_chart = await page.evaluate(() => !!(window as any).Chart.getChart("stacked_bar_chart"));
     expect(has_bar_chart).toBe(true);
+
+    // Built-in Chart.js legends are disabled (custom legend replaces them)
+    const pie_legend_on = await page.evaluate(() => (window as any).Chart.getChart("pie_chart")?.options.plugins.legend.display);
+    const bar_legend_on = await page.evaluate(() => (window as any).Chart.getChart("stacked_bar_chart")?.options.plugins.legend.display);
+    expect(pie_legend_on).toBe(false);
+    expect(bar_legend_on).toBe(false);
 });
 
 test("computes durations and pause/resume pairs per session", async ({ page }) => {
@@ -80,14 +89,14 @@ test("date preset filters sessions", async ({ page }) => {
     await expect(page.locator("#session_table_body tr")).toHaveCount(2);
 });
 
-test("job checkboxes filter sessions and sync the All checkbox", async ({ page }) => {
-    await page.locator("#job_filter_container .job-box[value='Beta']").uncheck();
+test("job legend checkboxes filter sessions and sync the All checkbox", async ({ page }) => {
+    await page.locator("#job_legend .legend-job-box[value='Beta']").uncheck();
     await expect(page.locator("#session_table_body tr")).toHaveCount(1);
     await expect(page.locator("#session_table_body tr")).toContainText("Alpha");
     await expect(page.locator("#job_all_checkbox")).not.toBeChecked();
 
     // Unchecking every job empties the table
-    await page.locator("#job_filter_container .job-box[value='Alpha']").uncheck();
+    await page.locator("#job_legend .legend-job-box[value='Alpha']").uncheck();
     await expect(page.locator("#session_table_body tr")).toHaveCount(0);
 
     // "All" re-checks every job
@@ -95,13 +104,13 @@ test("job checkboxes filter sessions and sync the All checkbox", async ({ page }
     await expect(page.locator("#session_table_body tr")).toHaveCount(2);
 });
 
-test("clear filters resets to this-month preset with all jobs", async ({ page }) => {
+test("reset restores the default Last 14 Days preset with all jobs", async ({ page }) => {
     await page.selectOption("#preset_range", "last_3_months");
-    await page.locator("#job_filter_container .job-box[value='Beta']").uncheck();
+    await page.locator("#job_legend .legend-job-box[value='Beta']").uncheck();
 
     await page.click("#clear_filters_btn");
 
-    await expect(page.locator("#preset_range")).toHaveValue("this_month");
+    await expect(page.locator("#preset_range")).toHaveValue("last_14");
     await expect(page.locator("#job_all_checkbox")).toBeChecked();
     await expect(page.locator("#session_table_body tr")).toHaveCount(2);
 });

--- a/tests/webview/dashboard.spec.ts
+++ b/tests/webview/dashboard.spec.ts
@@ -181,6 +181,27 @@ test("edit_result errors keep the modal open; success closes it", async ({ page 
     await expect(alpha_row.locator("td").nth(2)).toHaveText("2.25h");
 });
 
+test("edit modal: Escape cancels, Enter saves", async ({ page }) => {
+    const open_modal = () =>
+        page
+            .locator("#session_table_body tr", { hasText: "morning work" })
+            .locator("button.session-edit-btn")
+            .click();
+
+    // Escape closes without saving
+    await open_modal();
+    await expect(page.locator("#session_edit_modal")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator("#session_edit_modal")).toBeHidden();
+
+    // Enter acts as Save (no edits → modal just closes, nothing posted)
+    await open_modal();
+    await page.keyboard.press("Enter");
+    await expect(page.locator("#session_edit_modal")).toBeHidden();
+    const posted = await posted_messages(page);
+    expect(posted.find((m) => m.type === "edit_log_entries")).toBeUndefined();
+});
+
 test("highlighting marks matching session rows", async ({ page }) => {
     await page.evaluate((day) => (window as any).highlight_session_rows("Alpha", day), fx.today);
     const highlighted = page.locator("#session_table_body tr.session-highlighted");

--- a/tests/webview/dashboard.spec.ts
+++ b/tests/webview/dashboard.spec.ts
@@ -181,6 +181,95 @@ test("edit_result errors keep the modal open; success closes it", async ({ page 
     await expect(alpha_row.locator("td").nth(2)).toHaveText("2.25h");
 });
 
+test("active filters and sort survive an edit_result data reload", async ({ page }) => {
+    // Establish non-default state: wider preset, Beta hidden, duration-sorted
+    await page.selectOption("#preset_range", "last_3_months");
+    await page.locator("#job_legend .legend-job-box[value='Beta']").uncheck();
+    await page.locator("#session_table th[data-sort='duration'] .th-label").click();
+    await expect(page.locator("#session_table_body tr")).toHaveCount(2); // Alpha only
+
+    // Edit round-trip
+    const new_stop = await edit_alpha_stop(page);
+    const updated = fx.payload.map((e) =>
+        e.timestamp === fx.alpha_stop_ts ? { ...e, timestamp: new_stop.getTime() } : e
+    );
+    await reply(page, { type: "edit_result", payload: { summary: {}, payload: updated } });
+    await expect(page.locator("#session_edit_modal")).toBeHidden();
+
+    // Every piece of filter/sort state survived the reload
+    await expect(page.locator("#preset_range")).toHaveValue("last_3_months");
+    await expect(page.locator("#job_legend .legend-job-box[value='Beta']")).not.toBeChecked();
+    await expect(page.locator("#session_table th[data-sort='duration']")).toHaveClass(/sort-desc/);
+    const rows = page.locator("#session_table_body tr");
+    await expect(rows).toHaveCount(2);
+    for (const row of await rows.all()) await expect(row).toContainText("Alpha");
+    // Duration desc: the edited (now 2.25h) session leads
+    await expect(rows.nth(0).locator("td").nth(2)).toHaveText("2.25h");
+});
+
+test("clicking a bar segment highlights matching rows; clicking again clears (toggle)", async ({ page }) => {
+    // Pixel-click the center of Alpha's segment on today's bar through
+    // Chart.js hit-testing — not by calling the highlight helpers directly
+    const segment = async () => {
+        // The chart sits below the fold; mouse.click doesn't scroll, so bring
+        // it into view before mapping canvas coords to viewport coords
+        await page.locator("#stacked_bar_chart").scrollIntoViewIfNeeded();
+        const pos = await page.evaluate((day) => {
+            const chart = (window as any).Chart.getChart("stacked_bar_chart");
+            const ds_idx = chart.data.datasets.findIndex((d: any) => d.label === "Alpha");
+            const day_idx = chart.data.labels.indexOf(day);
+            const el = chart.getDatasetMeta(ds_idx).data[day_idx];
+            return { x: el.x, y: (el.y + el.base) / 2 };
+        }, fx.today);
+        const box = (await page.locator("#stacked_bar_chart").boundingBox())!;
+        return { x: box.x + pos.x, y: box.y + pos.y };
+    };
+
+    let p = await segment();
+    await page.mouse.click(p.x, p.y);
+    const highlighted = page.locator("#session_table_body tr.session-highlighted");
+    await expect(highlighted).toHaveCount(1);
+    await expect(highlighted).toContainText("Alpha");
+
+    p = await segment();
+    await page.mouse.click(p.x, p.y);
+    await expect(page.locator("#session_table_body tr.session-highlighted")).toHaveCount(0);
+});
+
+test("edit_result warnings keep the modal open with the warning shown; batch edits post together", async ({ page }) => {
+    // Batch: move both the start and the stop of today's Alpha session
+    await page
+        .locator("#session_table_body tr", { hasText: "morning work" })
+        .locator("button.session-edit-btn")
+        .click();
+    const event_rows = page.locator(".session-event-row");
+    const new_start = new Date(fx.alpha_stop_ts - 2 * 3600_000);
+    const new_stop = new Date(fx.alpha_stop_ts + 3600_000);
+    await event_rows.nth(0).locator("input[type='datetime-local']").fill(to_datetime_input_value(new_start.getTime()));
+    await event_rows.nth(3).locator("input[type='datetime-local']").fill(to_datetime_input_value(new_stop.getTime()));
+    await page.click("#session_edit_save");
+
+    const posted = await posted_messages(page);
+    const edit_msg = posted.find((m) => m.type === "edit_log_entries");
+    const { edits } = edit_msg!.payload as EditLogEntriesPayload;
+    expect(edits).toHaveLength(2);
+    expect(edits.map((e) => e.new_record.event).sort()).toEqual(["start", "stop"]);
+
+    // Warnings without errors: modal stays open, warning visible, Save re-enabled
+    await reply(page, {
+        type: "edit_result",
+        payload: { summary: { warnings: ["overlaps a session of another job"] }, payload: fx.payload },
+    });
+    await expect(page.locator("#session_edit_modal")).toBeVisible();
+    await expect(page.locator("#session_warning")).toBeVisible();
+    await expect(page.locator("#session_warning")).toContainText("overlaps a session of another job");
+    await expect(page.locator("#session_edit_save")).toBeEnabled();
+
+    // User acknowledges by cancelling
+    await page.click("#session_edit_cancel");
+    await expect(page.locator("#session_edit_modal")).toBeHidden();
+});
+
 test("edit modal: Escape cancels, Enter saves", async ({ page }) => {
     const open_modal = () =>
         page

--- a/tests/webview/dashboard.spec.ts
+++ b/tests/webview/dashboard.spec.ts
@@ -5,7 +5,7 @@ import { open_dashboard, posted_messages, reply, to_datetime_input_value } from 
 
 // Fixture: Alpha today 09:00–10:30 (1 pause/resume pair), Beta today
 // 13:00–14:00, Alpha 40 days ago 10:00–11:00. Time is frozen at FIXED_NOW,
-// and the default preset (Last 14 Days) is applied on load, so the 40-days-ago
+// and the default preset (Last 4 Weeks) is applied on load, so the 40-days-ago
 // session is filtered out until a wider preset is chosen.
 
 interface EditLogEntriesPayload {
@@ -39,8 +39,8 @@ test("loads, requests data, and renders charts, filters, and table", async ({ pa
     const posted = await posted_messages(page);
     expect(posted[0]).toEqual({ type: "request_data" });
 
-    // Default preset is Last 14 Days, applied on load (was bug #31)
-    await expect(page.locator("#preset_range")).toHaveValue("last_14");
+    // Default preset is Last 4 Weeks, applied on load (was bug #31)
+    await expect(page.locator("#preset_range")).toHaveValue("last_4_weeks");
 
     // Job legend: "All" + one checkbox per job, all checked initially
     await expect(page.locator("#job_all_checkbox")).toBeChecked();
@@ -104,13 +104,13 @@ test("job legend checkboxes filter sessions and sync the All checkbox", async ({
     await expect(page.locator("#session_table_body tr")).toHaveCount(2);
 });
 
-test("reset restores the default Last 14 Days preset with all jobs", async ({ page }) => {
+test("reset restores the default Last 4 Weeks preset with all jobs", async ({ page }) => {
     await page.selectOption("#preset_range", "last_3_months");
     await page.locator("#job_legend .legend-job-box[value='Beta']").uncheck();
 
     await page.click("#clear_filters_btn");
 
-    await expect(page.locator("#preset_range")).toHaveValue("last_14");
+    await expect(page.locator("#preset_range")).toHaveValue("last_4_weeks");
     await expect(page.locator("#job_all_checkbox")).toBeChecked();
     await expect(page.locator("#session_table_body tr")).toHaveCount(2);
 });

--- a/tests/webview/filtering.spec.ts
+++ b/tests/webview/filtering.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, Page } from "@playwright/test";
 
-import { build_filter_fixture, FilterFixtureData } from "./fixtures";
+import { build_filter_fixture, FilterFixtureData, FixtureEvent, FIXED_NOW } from "./fixtures";
 import { open_dashboard } from "./harness";
 
 // The 12-job filter fixture (see build_filter_fixture). Time is frozen at
@@ -158,19 +158,21 @@ test("duration range filters inclusively and recalculates charts", async ({ page
     await page.locator("#dur_min").fill("2");
     await page.locator("#dur_max").fill("4");
 
-    const jobs = await table_jobs(page);
-    expect(jobs.sort()).toEqual(["Beacon", "Cobalt", "Juno"]);
+    // Range inputs are debounced — poll until the pipeline has re-run
+    await expect.poll(async () => (await table_jobs(page)).sort())
+        .toEqual(["Beacon", "Cobalt", "Juno"]);
 
     // Pie recalculated to the same set
-    expect(Object.keys(await pie_data(page)).sort()).toEqual(["Beacon", "Cobalt", "Juno"]);
+    await expect.poll(async () => Object.keys(await pie_data(page)).sort())
+        .toEqual(["Beacon", "Cobalt", "Juno"]);
 });
 
 test("an empty duration bound is unbounded", async ({ page }) => {
     await page.selectOption("#preset_range", "all");
     await page.locator("#dur_min").fill("4"); // max left empty
 
-    // 4h and up: Juno 4h, Wolf 8h
-    expect((await table_jobs(page)).sort()).toEqual(["Juno", "Wolf"]);
+    // 4h and up: Juno 4h, Wolf 8h (debounced — poll)
+    await expect.poll(async () => (await table_jobs(page)).sort()).toEqual(["Juno", "Wolf"]);
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -184,7 +186,9 @@ test("pause range filters inclusively", async ({ page }) => {
     await page.locator("#pause_min").fill("1");
     await page.locator("#pause_max").fill("2");
 
-    expect((await table_jobs(page)).sort()).toEqual(["Beacon", "Cobalt", "Harbor"]);
+    // Range inputs are debounced — poll until the pipeline has re-run
+    await expect.poll(async () => (await table_jobs(page)).sort())
+        .toEqual(["Beacon", "Cobalt", "Harbor"]);
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -243,6 +247,37 @@ test("empty state appears when no sessions match and hides when they do", async 
 // ═══════════════════════════════════════════════════════════════════════════
 // Reset
 // ═══════════════════════════════════════════════════════════════════════════
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HTML/attribute injection hardening
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("job and task names with HTML metacharacters render as text and stay filterable", async ({ page }) => {
+    const hostile_job = `Ac"me <img src=x onerror="window.__pwned=1"> &Co`;
+    const start = FIXED_NOW.getTime() - 3600_000;
+    const payload: FixtureEvent[] = [
+        { event: "stop", job: hostile_job, timestamp: start + 3600_000, task: `<b>"task"</b>`, id: "x-2", job_id: "x", time_seed: start + 3600_000, global_line_index: 2, workspace_line_index: 2 },
+        { event: "start", job: hostile_job, timestamp: start, task: "", id: "x-1", job_id: "x", time_seed: start, global_line_index: 1, workspace_line_index: 1 },
+    ];
+    await open_dashboard(page, payload);
+
+    // No injected element executed or exists
+    expect(await page.evaluate(() => (window as any).__pwned)).toBeUndefined();
+    await expect(page.locator("#session_table_body img, #job_legend img")).toHaveCount(0);
+
+    // The names render as literal text in legend and table
+    await expect(page.locator("#job_legend .legend-row").nth(1)).toContainText(hostile_job);
+    await expect(page.locator("#session_table_body tr td").nth(1)).toHaveText(hostile_job);
+    await expect(page.locator("#session_table_body tr td").nth(3)).toHaveText(`<b>"task"</b>`);
+
+    // The checkbox round-trips the exact name: unchecking hides the session
+    const box = page.locator("#job_legend .legend-job-box");
+    await expect(box).toHaveCount(1);
+    await box.uncheck();
+    await expect(page.locator("#session_table_body tr")).toHaveCount(0);
+    await box.check();
+    await expect(page.locator("#session_table_body tr")).toHaveCount(1);
+});
 
 test("reset restores every filter to its default", async ({ page }) => {
     await page.selectOption("#preset_range", "all");

--- a/tests/webview/filtering.spec.ts
+++ b/tests/webview/filtering.spec.ts
@@ -127,14 +127,34 @@ test("funnels light up when their filter is actively limiting data", async ({ pa
     await page.locator("#job_legend .legend-job-box[value='Acme']").uncheck();
     await expect(page.locator("#job_filter_toggle")).toHaveClass(/filter-active/);
 
-    // Duration filter active
+    // Duration filter active — values commit on Enter, not per keystroke
     await page.locator("#dur_filter_toggle").click();
     await page.locator("#dur_min").fill("2");
+    await expect(page.locator("#dur_filter_toggle")).not.toHaveClass(/filter-active/); // not yet committed
+    await page.locator("#dur_min").press("Enter");
     await expect(page.locator("#dur_filter_toggle")).toHaveClass(/filter-active/);
 
     // Clearing the bound turns the funnel off again
+    await page.locator("#dur_filter_toggle").click();
     await page.locator("#dur_min").fill("");
+    await page.locator("#dur_min").press("Enter");
     await expect(page.locator("#dur_filter_toggle")).not.toHaveClass(/filter-active/);
+});
+
+test("typing a partial range value does not filter until committed", async ({ page }) => {
+    await page.selectOption("#preset_range", "all");
+    const before = (await table_jobs(page)).length;
+
+    // "0" typed but not committed: a max of 0h would hide everything if applied
+    await page.locator("#dur_filter_toggle").click();
+    await page.locator("#dur_max").pressSequentially("0");
+    await expect(page.locator("#session_table_body tr")).toHaveCount(before);
+
+    // Finishing the value and pressing Enter applies it and closes the menu
+    await page.locator("#dur_max").pressSequentially(".5");
+    await page.locator("#dur_max").press("Enter");
+    await expect.poll(async () => (await table_jobs(page)).sort()).toEqual(["Flint"]);
+    await expect(page.locator("#dur_max")).toBeHidden(); // menu closed by Enter
 });
 
 test("only one funnel menu is open at a time and Escape closes it", async ({ page }) => {
@@ -147,6 +167,31 @@ test("only one funnel menu is open at a time and Escape closes it", async ({ pag
 
     await page.keyboard.press("Escape");
     await expect(page.locator("#dur_min")).toBeHidden();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Legend hour totals
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("legend rows show per-job hours that track the date filter but not the job selection", async ({ page }) => {
+    const acme_row = page.locator("#job_legend .legend-row", { hasText: "Acme" });
+    const all_row = page.locator("#job_legend .legend-all");
+
+    // Acme worked 1h today; All shows the grand total of the visible window
+    await expect(acme_row.locator(".legend-hours")).toHaveText("(1.0h)");
+    await expect(all_row.locator(".legend-hours")).toContainText("h)");
+
+    // Narrowing the date range updates the numbers (Acme is outside "today"… it IS today)
+    await page.selectOption("#preset_range", "today");
+    await expect(acme_row.locator(".legend-hours")).toHaveText("(1.0h)");
+    await expect(all_row.locator(".legend-hours")).toHaveText("(1.0h)");
+
+    // Unchecking a job does NOT zero its own number — it still tells you
+    // what checking it would bring back
+    await page.selectOption("#preset_range", "last_14");
+    await acme_row.locator(".legend-job-box").uncheck();
+    await expect(page.locator("#job_legend .legend-row", { hasText: "Acme" }).locator(".legend-hours"))
+        .toHaveText("(1.0h)");
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -183,6 +228,7 @@ test("duration range filters inclusively and recalculates charts", async ({ page
     await page.locator("#dur_filter_toggle").click();
     await page.locator("#dur_min").fill("2");
     await page.locator("#dur_max").fill("4");
+    await page.locator("#dur_max").press("Enter");
 
     // Range inputs are debounced — poll until the pipeline has re-run
     await expect.poll(async () => (await table_jobs(page)).sort())
@@ -197,6 +243,7 @@ test("an empty duration bound is unbounded", async ({ page }) => {
     await page.selectOption("#preset_range", "all");
     await page.locator("#dur_filter_toggle").click();
     await page.locator("#dur_min").fill("4"); // max left empty
+    await page.locator("#dur_min").press("Enter");
 
     // 4h and up: Juno 4h, Wolf 8h (debounced — poll)
     await expect.poll(async () => (await table_jobs(page)).sort()).toEqual(["Juno", "Wolf"]);
@@ -213,6 +260,7 @@ test("pause range filters inclusively", async ({ page }) => {
     await page.locator("#pause_filter_toggle").click();
     await page.locator("#pause_min").fill("1");
     await page.locator("#pause_max").fill("2");
+    await page.locator("#pause_max").press("Enter");
 
     // Range inputs are debounced — poll until the pipeline has re-run
     await expect.poll(async () => (await table_jobs(page)).sort())
@@ -265,12 +313,15 @@ test("empty state appears when no sessions match and hides when they do", async 
     await page.selectOption("#preset_range", "all");
     await page.locator("#dur_filter_toggle").click();
     await page.locator("#dur_min").fill("100");
+    await page.locator("#dur_min").press("Enter");
 
     await expect(page.locator("#empty_state")).toBeVisible();
     await expect(page.locator("#session_table_body tr")).toHaveCount(0);
 
     // Clearing the impossible bound brings sessions back
+    await page.locator("#dur_filter_toggle").click();
     await page.locator("#dur_min").fill("");
+    await page.locator("#dur_min").press("Enter");
     await expect(page.locator("#empty_state")).toBeHidden();
 });
 
@@ -313,8 +364,10 @@ test("reset restores every filter to its default", async ({ page }) => {
     await page.selectOption("#preset_range", "all");
     await page.locator("#dur_filter_toggle").click();
     await page.locator("#dur_min").fill("2");
+    await page.locator("#dur_min").press("Enter");
     await page.locator("#pause_filter_toggle").click();
     await page.locator("#pause_max").fill("1");
+    await page.locator("#pause_max").press("Enter");
     await page.locator("#job_legend .legend-job-box[value='Acme']").uncheck();
 
     await page.click("#clear_filters_btn");

--- a/tests/webview/filtering.spec.ts
+++ b/tests/webview/filtering.spec.ts
@@ -1,0 +1,260 @@
+import { test, expect, Page } from "@playwright/test";
+
+import { build_filter_fixture, FilterFixtureData } from "./fixtures";
+import { open_dashboard } from "./harness";
+
+// The 12-job filter fixture (see build_filter_fixture). Time is frozen at
+// FIXED_NOW = 2026-07-15; the harness pins the page clock to the same instant.
+
+let ff: FilterFixtureData;
+
+test.beforeEach(async ({ page }) => {
+    ff = build_filter_fixture();
+    await open_dashboard(page, ff.payload);
+});
+
+/** Job names currently rendered in the sessions table, in row order. */
+async function table_jobs(page: Page): Promise<string[]> {
+    return page.locator("#session_table_body tr td:nth-child(2)").allTextContents();
+}
+
+/** The pie chart's current job → hours map, read from the live Chart.js instance. */
+async function pie_data(page: Page): Promise<Record<string, number>> {
+    return page.evaluate(() => {
+        const chart = (window as any).Chart.getChart("pie_chart");
+        const out: Record<string, number> = {};
+        chart.data.labels.forEach((label: string, i: number) => { out[label] = chart.data.datasets[0].data[i]; });
+        return out;
+    });
+}
+
+/** The pie chart's job → colour map, read from the live Chart.js instance. */
+async function pie_colors(page: Page): Promise<Record<string, string>> {
+    return page.evaluate(() => {
+        const chart = (window as any).Chart.getChart("pie_chart");
+        const out: Record<string, string> = {};
+        chart.data.labels.forEach((label: string, i: number) => { out[label] = chart.data.datasets[0].backgroundColor[i]; });
+        return out;
+    });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Default preset applied on load
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("default Last 14 Days preset is applied on load across table and charts", async ({ page }) => {
+    await expect(page.locator("#preset_range")).toHaveValue("last_14");
+
+    // Start/end inputs are populated with the resolved default range
+    await expect(page.locator("#start_date")).toHaveValue("2026-07-02");
+    await expect(page.locator("#end_date")).toHaveValue("2026-07-15");
+
+    // Ten of the twelve jobs fall inside the window; Wolf and Vega are excluded
+    const jobs = await table_jobs(page);
+    expect(jobs.sort()).toEqual(ff.jobs_in_last_14.slice().sort());
+    expect(jobs).not.toContain("Wolf");
+    expect(jobs).not.toContain("Vega");
+
+    // Charts agree with the table
+    const pie = await pie_data(page);
+    expect(Object.keys(pie).sort()).toEqual(ff.jobs_in_last_14.slice().sort());
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Preset ↔ date field interaction
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("selecting a preset fills the start/end date fields", async ({ page }) => {
+    await page.selectOption("#preset_range", "this_month");
+    await expect(page.locator("#start_date")).toHaveValue("2026-07-01");
+    await expect(page.locator("#end_date")).toHaveValue("2026-07-15");
+
+    await page.selectOption("#preset_range", "all");
+    await expect(page.locator("#start_date")).toHaveValue("");
+    await expect(page.locator("#end_date")).toHaveValue("");
+});
+
+test("editing a date field flips the preset to Custom", async ({ page }) => {
+    await page.locator("#start_date").fill("2026-07-05");
+    await page.locator("#start_date").blur();
+    await expect(page.locator("#preset_range")).toHaveValue("custom");
+});
+
+test("first date entered fills both start and end (single-day rule)", async ({ page }) => {
+    // Clear both by choosing "all", then enter a single start date
+    await page.selectOption("#preset_range", "all");
+    await page.locator("#start_date").fill("2026-07-10");
+    await page.locator("#start_date").blur();
+
+    await expect(page.locator("#end_date")).toHaveValue("2026-07-10");
+
+    // Only the 07-10 session (Flint) remains
+    expect(await table_jobs(page)).toEqual(["Flint"]);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Job legend ↔ table dropdown sync
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("unchecking a legend job updates the table dropdown and charts", async ({ page }) => {
+    await page.locator("#job_legend .legend-job-box[value='Acme']").uncheck();
+
+    // Dropdown reflects the same selection
+    await expect(page.locator("#job_dropdown_list .dropdown-job-box[value='Acme']")).not.toBeChecked();
+    // Both "All" boxes clear
+    await expect(page.locator("#job_all_checkbox")).not.toBeChecked();
+    await expect(page.locator("#job_dropdown_all")).not.toBeChecked();
+
+    // Acme is gone from the table and the pie
+    expect(await table_jobs(page)).not.toContain("Acme");
+    expect(Object.keys(await pie_data(page))).not.toContain("Acme");
+});
+
+test("unchecking a dropdown job updates the legend and charts", async ({ page }) => {
+    await page.locator("#job_dropdown_summary").click(); // open the <details>
+    await page.locator("#job_dropdown_list .dropdown-job-box[value='Beacon']").uncheck();
+
+    await expect(page.locator("#job_legend .legend-job-box[value='Beacon']")).not.toBeChecked();
+    expect(await table_jobs(page)).not.toContain("Beacon");
+});
+
+test("the dropdown summary reflects the selection count", async ({ page }) => {
+    await expect(page.locator("#job_dropdown_summary")).toHaveText("All jobs");
+    await page.locator("#job_legend .legend-job-box[value='Acme']").uncheck();
+    await expect(page.locator("#job_dropdown_summary")).toHaveText(/jobs$/);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Palette stability
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("job colours stay stable when other jobs are filtered out", async ({ page }) => {
+    // Widen to include all 12 jobs so the palette wraps (10-colour base)
+    await page.selectOption("#preset_range", "last_3_months");
+
+    const before = await pie_colors(page);
+
+    // Remove several jobs
+    await page.locator("#job_legend .legend-job-box[value='Cobalt']").uncheck();
+    await page.locator("#job_legend .legend-job-box[value='Delta']").uncheck();
+
+    const after = await pie_colors(page);
+
+    // Every job that remains kept its exact colour
+    for (const job of Object.keys(after)) {
+        expect(after[job]).toBe(before[job]);
+    }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Duration range filter
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("duration range filters inclusively and recalculates charts", async ({ page }) => {
+    await page.selectOption("#preset_range", "all"); // all 12 sessions in play
+
+    // Sessions with duration between 2h and 4h inclusive:
+    // Beacon 2h, Cobalt 3h, Juno 4h (Acme/Delta/... 1h excluded, Wolf 8h excluded)
+    await page.locator("#dur_min").fill("2");
+    await page.locator("#dur_max").fill("4");
+
+    const jobs = await table_jobs(page);
+    expect(jobs.sort()).toEqual(["Beacon", "Cobalt", "Juno"]);
+
+    // Pie recalculated to the same set
+    expect(Object.keys(await pie_data(page)).sort()).toEqual(["Beacon", "Cobalt", "Juno"]);
+});
+
+test("an empty duration bound is unbounded", async ({ page }) => {
+    await page.selectOption("#preset_range", "all");
+    await page.locator("#dur_min").fill("4"); // max left empty
+
+    // 4h and up: Juno 4h, Wolf 8h
+    expect((await table_jobs(page)).sort()).toEqual(["Juno", "Wolf"]);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Pause range filter
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("pause range filters inclusively", async ({ page }) => {
+    await page.selectOption("#preset_range", "all");
+
+    // Pause pairs: Acme 0, Beacon 1, Harbor 1, Cobalt 2, Juno 3
+    await page.locator("#pause_min").fill("1");
+    await page.locator("#pause_max").fill("2");
+
+    expect((await table_jobs(page)).sort()).toEqual(["Beacon", "Cobalt", "Harbor"]);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Sorting
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("clicking a column header sorts and toggles direction", async ({ page }) => {
+    await page.selectOption("#preset_range", "all");
+
+    // Default sort is start desc (newest first): Acme (07-15) leads
+    let jobs = await table_jobs(page);
+    expect(jobs[0]).toBe("Acme");
+    expect(jobs[jobs.length - 1]).toBe("Vega"); // 06-20, oldest
+
+    // First click on a new column sorts descending (reverse alphabetical)
+    await page.locator("#session_table th[data-sort='job']").click();
+    jobs = await table_jobs(page);
+    expect(jobs).toEqual([...jobs].sort((a, b) => b.localeCompare(a)));
+    await expect(page.locator("#session_table th[data-sort='job']")).toHaveClass(/sort-desc/);
+
+    // Second click toggles to ascending
+    await page.locator("#session_table th[data-sort='job']").click();
+    jobs = await table_jobs(page);
+    expect(jobs).toEqual([...jobs].sort((a, b) => a.localeCompare(b)));
+    await expect(page.locator("#session_table th[data-sort='job']")).toHaveClass(/sort-asc/);
+});
+
+test("sorting by duration orders by active hours", async ({ page }) => {
+    await page.selectOption("#preset_range", "all");
+    await page.locator("#session_table th[data-sort='duration']").click(); // desc
+
+    const jobs = await table_jobs(page);
+    // Longest first: Wolf 8h, then Juno 4h, then Cobalt 3h
+    expect(jobs.slice(0, 3)).toEqual(["Wolf", "Juno", "Cobalt"]);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Empty state
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("empty state appears when no sessions match and hides when they do", async ({ page }) => {
+    await expect(page.locator("#empty_state")).toBeHidden();
+
+    // A window with no sessions
+    await page.selectOption("#preset_range", "all");
+    await page.locator("#dur_min").fill("100");
+
+    await expect(page.locator("#empty_state")).toBeVisible();
+    await expect(page.locator("#session_table_body tr")).toHaveCount(0);
+
+    // Clearing the impossible bound brings sessions back
+    await page.locator("#dur_min").fill("");
+    await expect(page.locator("#empty_state")).toBeHidden();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Reset
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("reset restores every filter to its default", async ({ page }) => {
+    await page.selectOption("#preset_range", "all");
+    await page.locator("#dur_min").fill("2");
+    await page.locator("#pause_max").fill("1");
+    await page.locator("#job_legend .legend-job-box[value='Acme']").uncheck();
+
+    await page.click("#clear_filters_btn");
+
+    await expect(page.locator("#preset_range")).toHaveValue("last_14");
+    await expect(page.locator("#dur_min")).toHaveValue("");
+    await expect(page.locator("#pause_max")).toHaveValue("");
+    await expect(page.locator("#job_all_checkbox")).toBeChecked();
+    expect((await table_jobs(page)).sort()).toEqual(ff.jobs_in_last_14.slice().sort());
+});

--- a/tests/webview/filtering.spec.ts
+++ b/tests/webview/filtering.spec.ts
@@ -435,14 +435,17 @@ test("empty result shows a prominent message in place of the pie chart", async (
     await expect(page.locator("#pie_chart")).toBeVisible();
 });
 
-test("narrow panels abbreviate the Duration and Pause/Resume headers", async ({ page }) => {
-    // Wide: full titles
-    await expect(page.locator("th[data-sort='duration'] .th-full")).toBeVisible();
-    await expect(page.locator("th[data-sort='pauses'] .th-short")).toBeHidden();
+test("Pause/Resume is always P/R with a tooltip; Duration abbreviates at half-screen widths", async ({ page }) => {
+    // Pause/Resume: permanent abbreviation with the full name in the tooltip
+    const pr_label = page.locator("th[data-sort='pauses'] .th-label");
+    await expect(pr_label).toHaveText("P/R");
+    await expect(pr_label).toHaveAttribute("title", "Pause/Resume");
 
-    // Narrow (half-screen-ish): abbreviations take over
-    await page.setViewportSize({ width: 700, height: 900 });
+    // Wide (default 1280px viewport): Duration shows its full title
+    await expect(page.locator("th[data-sort='duration'] .th-full")).toBeVisible();
+
+    // Half-screen-ish (≤1200px): Duration abbreviates
+    await page.setViewportSize({ width: 1100, height: 900 });
     await expect(page.locator("th[data-sort='duration'] .th-full")).toBeHidden();
     await expect(page.locator("th[data-sort='duration'] .th-short")).toBeVisible();
-    await expect(page.locator("th[data-sort='pauses'] .th-short")).toHaveText("P/R");
 });

--- a/tests/webview/filtering.spec.ts
+++ b/tests/webview/filtering.spec.ts
@@ -42,22 +42,23 @@ async function pie_colors(page: Page): Promise<Record<string, string>> {
 // Default preset applied on load
 // ═══════════════════════════════════════════════════════════════════════════
 
-test("default Last 14 Days preset is applied on load across table and charts", async ({ page }) => {
-    await expect(page.locator("#preset_range")).toHaveValue("last_14");
+test("default Last 4 Weeks preset is applied on load across table and charts", async ({ page }) => {
+    await expect(page.locator("#preset_range")).toHaveValue("last_4_weeks");
 
     // Start/end inputs are populated with the resolved default range
-    await expect(page.locator("#start_date")).toHaveValue("2026-07-02");
+    await expect(page.locator("#start_date")).toHaveValue("2026-06-18");
     await expect(page.locator("#end_date")).toHaveValue("2026-07-15");
 
-    // Ten of the twelve jobs fall inside the window; Wolf and Vega are excluded
+    // Eleven of the twelve jobs fall inside the window (Wolf sits exactly on
+    // the start boundary); only Vega is excluded
     const jobs = await table_jobs(page);
-    expect(jobs.sort()).toEqual(ff.jobs_in_last_14.slice().sort());
-    expect(jobs).not.toContain("Wolf");
+    expect(jobs.sort()).toEqual(ff.jobs_in_default_range.slice().sort());
+    expect(jobs).toContain("Wolf");
     expect(jobs).not.toContain("Vega");
 
     // Charts agree with the table
     const pie = await pie_data(page);
-    expect(Object.keys(pie).sort()).toEqual(ff.jobs_in_last_14.slice().sort());
+    expect(Object.keys(pie).sort()).toEqual(ff.jobs_in_default_range.slice().sort());
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -397,11 +398,51 @@ test("reset restores every filter to its default", async ({ page }) => {
 
     await page.click("#clear_filters_btn");
 
-    await expect(page.locator("#preset_range")).toHaveValue("last_14");
+    await expect(page.locator("#preset_range")).toHaveValue("last_4_weeks");
     await expect(page.locator("#job_all_checkbox")).toBeChecked();
     // Funnel indicators are all off again
     await expect(page.locator("#job_filter_toggle")).not.toHaveClass(/filter-active/);
     await expect(page.locator("#dur_filter_toggle")).not.toHaveClass(/filter-active/);
     await expect(page.locator("#pause_filter_toggle")).not.toHaveClass(/filter-active/);
-    expect((await table_jobs(page)).sort()).toEqual(ff.jobs_in_last_14.slice().sort());
+    expect((await table_jobs(page)).sort()).toEqual(ff.jobs_in_default_range.slice().sort());
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Narrow-panel and legend affordances
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("legend names carry a tooltip with the full job name", async ({ page }) => {
+    const acme_text = page.locator("#job_legend .legend-row", { hasText: "Acme" }).locator(".legend-text");
+    await expect(acme_text).toHaveAttribute("title", "Acme");
+});
+
+test("empty result shows a prominent message in place of the pie chart", async ({ page }) => {
+    await expect(page.locator("#pie_empty")).toBeHidden();
+
+    // A range no session satisfies
+    await page.locator("#dur_filter_toggle").click();
+    await page.locator("#dur_min").fill("100");
+    await page.locator("#dur_min").press("Enter");
+
+    await expect(page.locator("#pie_empty")).toBeVisible();
+    await expect(page.locator("#pie_empty")).toContainText("No data in the selected date range or filters");
+    await expect(page.locator("#pie_chart")).toBeHidden();
+
+    // Data back → chart back
+    await page.locator("#dur_filter_toggle").click();
+    await page.locator("#dur_filter_clear").click();
+    await expect(page.locator("#pie_empty")).toBeHidden();
+    await expect(page.locator("#pie_chart")).toBeVisible();
+});
+
+test("narrow panels abbreviate the Duration and Pause/Resume headers", async ({ page }) => {
+    // Wide: full titles
+    await expect(page.locator("th[data-sort='duration'] .th-full")).toBeVisible();
+    await expect(page.locator("th[data-sort='pauses'] .th-short")).toBeHidden();
+
+    // Narrow (half-screen-ish): abbreviations take over
+    await page.setViewportSize({ width: 700, height: 900 });
+    await expect(page.locator("th[data-sort='duration'] .th-full")).toBeHidden();
+    await expect(page.locator("th[data-sort='duration'] .th-short")).toBeVisible();
+    await expect(page.locator("th[data-sort='pauses'] .th-short")).toHaveText("P/R");
 });

--- a/tests/webview/filtering.spec.ts
+++ b/tests/webview/filtering.spec.ts
@@ -196,6 +196,59 @@ test("only one funnel menu is open at a time and Escape closes it", async ({ pag
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Stacked bar data
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("stacked bar buckets hours per local day per job", async ({ page }) => {
+    await page.selectOption("#preset_range", "all");
+
+    const bar = await page.evaluate(() => {
+        const chart = (window as any).Chart.getChart("stacked_bar_chart");
+        return {
+            labels: chart.data.labels,
+            datasets: chart.data.datasets.map((d: any) => ({ label: d.label, data: d.data })),
+        };
+    });
+
+    // One column per active day, twelve datasets (one per job), alphabetical
+    expect(bar.labels.length).toBe(12);
+    expect(bar.datasets.map((d: { label: string }) => d.label)).toEqual(
+        ff.jobs.slice().sort((a, b) => a.localeCompare(b)));
+
+    // Spot-check a bucket: Beacon logged 2h on its day, 0h elsewhere
+    const beacon = bar.datasets.find((d: { label: string }) => d.label === "Beacon")!;
+    expect(Math.max(...beacon.data)).toBe(2);
+    expect(beacon.data.filter((v: number) => v > 0).length).toBe(1);
+});
+
+test("per-day total label renders even when the last dataset has no hours that day (regression)", async ({ page }) => {
+    await page.selectOption("#preset_range", "all");
+
+    const result = await page.evaluate(() => {
+        const chart = (window as any).Chart.getChart("stacked_bar_chart");
+        const datasets = chart.data.datasets;
+        const last = datasets.length - 1;
+        // Find a day where the alphabetically-last job (Wolf) logged nothing
+        // but others did — e.g. Acme's day
+        const acme = datasets.find((d: any) => d.label === "Acme");
+        const day_idx = acme.data.findIndex((v: number) => v > 0);
+        // Read the formatter from the raw config — the chart.options proxy
+        // treats function values as scriptables and invokes them on access
+        const fmt = chart.config.options.plugins.datalabels.formatter;
+        return {
+            last_label: datasets[last].label,
+            last_value_that_day: datasets[last].data[day_idx],
+            rendered: fmt(datasets[last].data[day_idx], { datasetIndex: last, dataIndex: day_idx, chart }),
+        };
+    });
+
+    // The zero-height last segment must still carry the day total
+    expect(result.last_label).toBe("Wolf");
+    expect(result.last_value_that_day).toBe(0);
+    expect(result.rendered).toBe("1.0h"); // Acme's 1h is that day's total
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Legend hour totals
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/tests/webview/filtering.spec.ts
+++ b/tests/webview/filtering.spec.ts
@@ -110,18 +110,43 @@ test("unchecking a legend job updates the table dropdown and charts", async ({ p
     expect(Object.keys(await pie_data(page))).not.toContain("Acme");
 });
 
-test("unchecking a dropdown job updates the legend and charts", async ({ page }) => {
-    await page.locator("#job_dropdown_summary").click(); // open the <details>
+test("unchecking a job in the column funnel menu updates the legend and charts", async ({ page }) => {
+    await page.locator("#job_filter_toggle").click(); // open the funnel menu
     await page.locator("#job_dropdown_list .dropdown-job-box[value='Beacon']").uncheck();
 
     await expect(page.locator("#job_legend .legend-job-box[value='Beacon']")).not.toBeChecked();
     expect(await table_jobs(page)).not.toContain("Beacon");
 });
 
-test("the dropdown summary reflects the selection count", async ({ page }) => {
-    await expect(page.locator("#job_dropdown_summary")).toHaveText("All jobs");
+test("funnels light up when their filter is actively limiting data", async ({ page }) => {
+    // Inactive by default
+    await expect(page.locator("#job_filter_toggle")).not.toHaveClass(/filter-active/);
+    await expect(page.locator("#dur_filter_toggle")).not.toHaveClass(/filter-active/);
+
+    // Job filter active (driven from the legend — the synced surface)
     await page.locator("#job_legend .legend-job-box[value='Acme']").uncheck();
-    await expect(page.locator("#job_dropdown_summary")).toHaveText(/jobs$/);
+    await expect(page.locator("#job_filter_toggle")).toHaveClass(/filter-active/);
+
+    // Duration filter active
+    await page.locator("#dur_filter_toggle").click();
+    await page.locator("#dur_min").fill("2");
+    await expect(page.locator("#dur_filter_toggle")).toHaveClass(/filter-active/);
+
+    // Clearing the bound turns the funnel off again
+    await page.locator("#dur_min").fill("");
+    await expect(page.locator("#dur_filter_toggle")).not.toHaveClass(/filter-active/);
+});
+
+test("only one funnel menu is open at a time and Escape closes it", async ({ page }) => {
+    await page.locator("#job_filter_toggle").click();
+    await expect(page.locator("#job_dropdown_list")).toBeVisible();
+
+    await page.locator("#dur_filter_toggle").click();
+    await expect(page.locator("#dur_min")).toBeVisible();
+    await expect(page.locator("#job_dropdown_list")).toBeHidden();
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator("#dur_min")).toBeHidden();
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -155,6 +180,7 @@ test("duration range filters inclusively and recalculates charts", async ({ page
 
     // Sessions with duration between 2h and 4h inclusive:
     // Beacon 2h, Cobalt 3h, Juno 4h (Acme/Delta/... 1h excluded, Wolf 8h excluded)
+    await page.locator("#dur_filter_toggle").click();
     await page.locator("#dur_min").fill("2");
     await page.locator("#dur_max").fill("4");
 
@@ -169,6 +195,7 @@ test("duration range filters inclusively and recalculates charts", async ({ page
 
 test("an empty duration bound is unbounded", async ({ page }) => {
     await page.selectOption("#preset_range", "all");
+    await page.locator("#dur_filter_toggle").click();
     await page.locator("#dur_min").fill("4"); // max left empty
 
     // 4h and up: Juno 4h, Wolf 8h (debounced — poll)
@@ -183,6 +210,7 @@ test("pause range filters inclusively", async ({ page }) => {
     await page.selectOption("#preset_range", "all");
 
     // Pause pairs: Acme 0, Beacon 1, Harbor 1, Cobalt 2, Juno 3
+    await page.locator("#pause_filter_toggle").click();
     await page.locator("#pause_min").fill("1");
     await page.locator("#pause_max").fill("2");
 
@@ -203,14 +231,15 @@ test("clicking a column header sorts and toggles direction", async ({ page }) =>
     expect(jobs[0]).toBe("Acme");
     expect(jobs[jobs.length - 1]).toBe("Vega"); // 06-20, oldest
 
-    // First click on a new column sorts descending (reverse alphabetical)
-    await page.locator("#session_table th[data-sort='job']").click();
+    // First click on a new column sorts descending (reverse alphabetical).
+    // Click the label — the header also hosts the funnel toggle.
+    await page.locator("#session_table th[data-sort='job'] .th-label").click();
     jobs = await table_jobs(page);
     expect(jobs).toEqual([...jobs].sort((a, b) => b.localeCompare(a)));
     await expect(page.locator("#session_table th[data-sort='job']")).toHaveClass(/sort-desc/);
 
     // Second click toggles to ascending
-    await page.locator("#session_table th[data-sort='job']").click();
+    await page.locator("#session_table th[data-sort='job'] .th-label").click();
     jobs = await table_jobs(page);
     expect(jobs).toEqual([...jobs].sort((a, b) => a.localeCompare(b)));
     await expect(page.locator("#session_table th[data-sort='job']")).toHaveClass(/sort-asc/);
@@ -218,7 +247,7 @@ test("clicking a column header sorts and toggles direction", async ({ page }) =>
 
 test("sorting by duration orders by active hours", async ({ page }) => {
     await page.selectOption("#preset_range", "all");
-    await page.locator("#session_table th[data-sort='duration']").click(); // desc
+    await page.locator("#session_table th[data-sort='duration'] .th-label").click(); // desc
 
     const jobs = await table_jobs(page);
     // Longest first: Wolf 8h, then Juno 4h, then Cobalt 3h
@@ -234,6 +263,7 @@ test("empty state appears when no sessions match and hides when they do", async 
 
     // A window with no sessions
     await page.selectOption("#preset_range", "all");
+    await page.locator("#dur_filter_toggle").click();
     await page.locator("#dur_min").fill("100");
 
     await expect(page.locator("#empty_state")).toBeVisible();
@@ -281,15 +311,19 @@ test("job and task names with HTML metacharacters render as text and stay filter
 
 test("reset restores every filter to its default", async ({ page }) => {
     await page.selectOption("#preset_range", "all");
+    await page.locator("#dur_filter_toggle").click();
     await page.locator("#dur_min").fill("2");
+    await page.locator("#pause_filter_toggle").click();
     await page.locator("#pause_max").fill("1");
     await page.locator("#job_legend .legend-job-box[value='Acme']").uncheck();
 
     await page.click("#clear_filters_btn");
 
     await expect(page.locator("#preset_range")).toHaveValue("last_14");
-    await expect(page.locator("#dur_min")).toHaveValue("");
-    await expect(page.locator("#pause_max")).toHaveValue("");
     await expect(page.locator("#job_all_checkbox")).toBeChecked();
+    // Funnel indicators are all off again
+    await expect(page.locator("#job_filter_toggle")).not.toHaveClass(/filter-active/);
+    await expect(page.locator("#dur_filter_toggle")).not.toHaveClass(/filter-active/);
+    await expect(page.locator("#pause_filter_toggle")).not.toHaveClass(/filter-active/);
     expect((await table_jobs(page)).sort()).toEqual(ff.jobs_in_last_14.slice().sort());
 });

--- a/tests/webview/filtering.spec.ts
+++ b/tests/webview/filtering.spec.ts
@@ -157,6 +157,31 @@ test("typing a partial range value does not filter until committed", async ({ pa
     await expect(page.locator("#dur_max")).toBeHidden(); // menu closed by Enter
 });
 
+test("each funnel menu's Clear button removes only that column's filter", async ({ page }) => {
+    await page.selectOption("#preset_range", "all");
+
+    // Constrain duration AND jobs
+    await page.locator("#dur_filter_toggle").click();
+    await page.locator("#dur_min").fill("2");
+    await page.locator("#dur_min").press("Enter");
+    await page.locator("#job_legend .legend-job-box[value='Acme']").uncheck();
+    await expect(page.locator("#dur_filter_toggle")).toHaveClass(/filter-active/);
+    await expect(page.locator("#job_filter_toggle")).toHaveClass(/filter-active/);
+
+    // Clearing duration leaves the job filter intact
+    await page.locator("#dur_filter_toggle").click();
+    await page.locator("#dur_filter_clear").click();
+    await expect(page.locator("#dur_filter_toggle")).not.toHaveClass(/filter-active/);
+    await expect(page.locator("#job_filter_toggle")).toHaveClass(/filter-active/);
+    await expect(page.locator("#dur_min")).toBeHidden(); // menu closed
+
+    // Clearing jobs re-selects everything
+    await page.locator("#job_filter_toggle").click();
+    await page.locator("#job_filter_clear").click();
+    await expect(page.locator("#job_filter_toggle")).not.toHaveClass(/filter-active/);
+    await expect(page.locator("#job_all_checkbox")).toBeChecked();
+});
+
 test("only one funnel menu is open at a time and Escape closes it", async ({ page }) => {
     await page.locator("#job_filter_toggle").click();
     await expect(page.locator("#job_dropdown_list")).toBeVisible();

--- a/tests/webview/fixtures.ts
+++ b/tests/webview/fixtures.ts
@@ -5,8 +5,10 @@
  * timestamp-descending array of { event, job, timestamp, task, id, job_id,
  * time_seed, global_line_index, workspace_line_index }.
  *
- * Timestamps are generated relative to "now" so the dashboard's relative
- * date presets (today / this month / last 3 months) behave predictably.
+ * Time is frozen: fixtures are generated relative to FIXED_NOW, and the
+ * harness pins the page clock to the same instant (page.clock.setFixedTime).
+ * This removes the old "run straddling local midnight" flake — the dashboard's
+ * relative date presets now resolve against a fixed, known day.
  */
 
 export interface FixtureEvent {
@@ -20,6 +22,13 @@ export interface FixtureEvent {
     global_line_index: number;
     workspace_line_index: number;
 }
+
+/**
+ * The frozen "now" all fixtures and the page clock share:
+ * Wednesday 2026-07-15, 12:00 local. Chosen mid-week and mid-month so the
+ * this_week / this_month presets have a non-trivial span to assert against.
+ */
+export const FIXED_NOW = new Date(2026, 6, 15, 12, 0, 0, 0);
 
 /** Same local-day formatting the dashboard uses (get_local_day). */
 function local_day(timestamp: number): string {
@@ -45,16 +54,15 @@ export interface FixtureData {
 }
 
 /**
- * Three closed sessions:
+ * Three closed sessions (relative to FIXED_NOW = 2026-07-15):
  * - Alpha, today 09:00–10:30 with one pause/resume pair (09:45–10:00), task "morning work"
  * - Beta,  today 13:00–14:00, task "beta task"
- * - Alpha, 40 days ago 10:00–11:00 (inside "last 3 months", outside "this month" and "today")
+ * - Alpha, 40 days ago 10:00–11:00 (inside "last 3 months", outside "last 14 days")
+ *
+ * Kept intentionally small: this fixture backs the edit-modal, highlighting,
+ * and build-info tests. Filtering behaviour is exercised by build_filter_fixture.
  */
-export function build_fixture(): FixtureData {
-    // Known flake window: "today" is stamped here, but the dashboard recomputes
-    // its own "today" at filter time — a run straddling local midnight can
-    // disagree. Accepted: the window is one page-load wide.
-    const now = new Date();
+export function build_fixture(now: Date = FIXED_NOW): FixtureData {
     const old = new Date(now.getTime() - 40 * 24 * 3600 * 1000);
 
     let line = 0;
@@ -94,4 +102,112 @@ export function build_fixture(): FixtureData {
         today: local_day(now.getTime()),
         alpha_stop_ts,
     };
+}
+
+/** One planned session in the filtering fixture. */
+export interface FilterFixtureSession {
+    job: string;
+    /** Local day of the session ("YYYY-MM-DD"). */
+    day: string;
+    /** Active duration in hours (pause gaps are zero-length, so span == active). */
+    hours: number;
+    /** Number of pause/resume pairs. */
+    pauses: number;
+    /** Log provenance — controls has_global/has_workspace for the #3 source seam. */
+    source: "merged" | "global" | "workspace";
+}
+
+export interface FilterFixtureData {
+    payload: FixtureEvent[];
+    sessions: FilterFixtureSession[];
+    /** All job names, in creation order (matches palette assignment order). */
+    jobs: string[];
+    /** Jobs whose session falls inside the default Last-14-Days window. */
+    jobs_in_last_14: string[];
+}
+
+/**
+ * A twelve-job fixture built for filter/sort coverage (relative to FIXED_NOW):
+ *
+ * - 12 jobs → exercises the scrollable legend and palette wrap (10-colour base).
+ * - Sessions placed on preset boundaries: 07-02 (Last-14 start), 07-01 (this
+ *   month, outside Last-14), 06-20 (Last-3-months only).
+ * - Duration spread 0.5h..8h with exact boundary values for the range filter.
+ * - Pause spread 0..3 pairs (zero-length gaps keep durations exact).
+ * - One global-only and one workspace-only session for the source seam.
+ *
+ * Ten of the twelve sessions fall inside the default Last-14-Days window;
+ * Wolf (07-01) and Vega (06-20) fall outside it.
+ */
+export function build_filter_fixture(now: Date = FIXED_NOW): FilterFixtureData {
+    const plan: FilterFixtureSession[] = [
+        { job: "Acme", day: local_day(at_local_time(now, 9, 0)), hours: 1.0, pauses: 0, source: "merged" },      // today 07-15
+        { job: "Beacon", day: shift_day(now, -1), hours: 2.0, pauses: 1, source: "merged" },                     // 07-14
+        { job: "Cobalt", day: shift_day(now, -2), hours: 3.0, pauses: 2, source: "merged" },                     // 07-13
+        { job: "Delta", day: shift_day(now, -3), hours: 1.0, pauses: 0, source: "merged" },                      // 07-12
+        { job: "Ember", day: shift_day(now, -4), hours: 1.0, pauses: 0, source: "global" },                      // 07-11 global-only
+        { job: "Flint", day: shift_day(now, -5), hours: 0.5, pauses: 0, source: "workspace" },                   // 07-10 workspace-only
+        { job: "Gale", day: shift_day(now, -6), hours: 1.0, pauses: 0, source: "merged" },                       // 07-09
+        { job: "Harbor", day: shift_day(now, -7), hours: 1.0, pauses: 1, source: "merged" },                     // 07-08
+        { job: "Iris", day: shift_day(now, -8), hours: 1.0, pauses: 0, source: "merged" },                       // 07-07
+        { job: "Juno", day: shift_day(now, -13), hours: 4.0, pauses: 3, source: "merged" },                      // 07-02 Last-14 start boundary
+        { job: "Wolf", day: shift_day(now, -14), hours: 8.0, pauses: 0, source: "merged" },                      // 07-01 outside Last-14
+        { job: "Vega", day: shift_day(now, -25), hours: 1.0, pauses: 0, source: "merged" },                      // 06-20 Last-3-months only
+    ];
+
+    let line = 0;
+    const events: FixtureEvent[] = [];
+
+    const push = (
+        event: string,
+        job: string,
+        job_id: string,
+        timestamp: number,
+        source: FilterFixtureSession["source"],
+        task = ""
+    ): void => {
+        line += 1;
+        events.push({
+            event,
+            job,
+            timestamp,
+            task,
+            id: `ff-${line}`,
+            job_id,
+            time_seed: timestamp,
+            global_line_index: source === "workspace" ? -1 : line,
+            workspace_line_index: source === "global" ? -1 : line,
+        });
+    };
+
+    for (const s of plan) {
+        const job_id = s.job.toLowerCase();
+        const base = new Date(`${s.day}T00:00:00`);
+        const start = at_local_time(base, 9, 0);
+        const active_ms = Math.round(s.hours * 3600_000);
+        const stop = start + active_ms;
+
+        push("start", s.job, job_id, start, s.source);
+        // Zero-length pause gaps: paused time is 0, so active duration == span.
+        for (let p = 0; p < s.pauses; p++) {
+            const at = start + 60_000 * (p + 1);
+            push("pause", s.job, job_id, at, s.source);
+            push("resume", s.job, job_id, at, s.source);
+        }
+        push("stop", s.job, job_id, stop, s.source, `${s.job} work`);
+    }
+
+    return {
+        payload: events.slice().sort((a, b) => b.timestamp - a.timestamp),
+        sessions: plan,
+        jobs: plan.map(s => s.job),
+        jobs_in_last_14: plan.filter(s => s.day >= shift_day(now, -13)).map(s => s.job),
+    };
+}
+
+/** Local-day string N days before `now` (N negative = past). */
+function shift_day(now: Date, delta_days: number): string {
+    const d = new Date(now);
+    d.setDate(now.getDate() + delta_days);
+    return local_day(d.getTime());
 }

--- a/tests/webview/fixtures.ts
+++ b/tests/webview/fixtures.ts
@@ -119,8 +119,7 @@ export interface FilterFixtureSession {
 
 export interface FilterFixtureData {
     payload: FixtureEvent[];
-    sessions: FilterFixtureSession[];
-    /** All job names, in creation order (matches palette assignment order). */
+    /** All job names, in creation order. */
     jobs: string[];
     /** Jobs whose session falls inside the default Last-14-Days window. */
     jobs_in_last_14: string[];
@@ -199,7 +198,6 @@ export function build_filter_fixture(now: Date = FIXED_NOW): FilterFixtureData {
 
     return {
         payload: events.slice().sort((a, b) => b.timestamp - a.timestamp),
-        sessions: plan,
         jobs: plan.map(s => s.job),
         jobs_in_last_14: plan.filter(s => s.day >= shift_day(now, -13)).map(s => s.job),
     };

--- a/tests/webview/fixtures.ts
+++ b/tests/webview/fixtures.ts
@@ -121,22 +121,22 @@ export interface FilterFixtureData {
     payload: FixtureEvent[];
     /** All job names, in creation order. */
     jobs: string[];
-    /** Jobs whose session falls inside the default Last-14-Days window. */
-    jobs_in_last_14: string[];
+    /** Jobs whose session falls inside the default Last-4-Weeks window. */
+    jobs_in_default_range: string[];
 }
 
 /**
  * A twelve-job fixture built for filter/sort coverage (relative to FIXED_NOW):
  *
  * - 12 jobs → exercises the scrollable legend and palette wrap (10-colour base).
- * - Sessions placed on preset boundaries: 07-02 (Last-14 start), 07-01 (this
- *   month, outside Last-14), 06-20 (Last-3-months only).
+ * - Sessions placed on preset boundaries: 06-18 (Last-4-Weeks start boundary,
+ *   Wolf), 06-10 (outside the default window, Vega).
  * - Duration spread 0.5h..8h with exact boundary values for the range filter.
  * - Pause spread 0..3 pairs (zero-length gaps keep durations exact).
  * - One global-only and one workspace-only session for the source seam.
  *
- * Ten of the twelve sessions fall inside the default Last-14-Days window;
- * Wolf (07-01) and Vega (06-20) fall outside it.
+ * Eleven of the twelve sessions fall inside the default Last-4-Weeks window;
+ * only Vega (06-10) falls outside it.
  */
 export function build_filter_fixture(now: Date = FIXED_NOW): FilterFixtureData {
     const plan: FilterFixtureSession[] = [
@@ -149,9 +149,9 @@ export function build_filter_fixture(now: Date = FIXED_NOW): FilterFixtureData {
         { job: "Gale", day: shift_day(now, -6), hours: 1.0, pauses: 0, source: "merged" },                       // 07-09
         { job: "Harbor", day: shift_day(now, -7), hours: 1.0, pauses: 1, source: "merged" },                     // 07-08
         { job: "Iris", day: shift_day(now, -8), hours: 1.0, pauses: 0, source: "merged" },                       // 07-07
-        { job: "Juno", day: shift_day(now, -13), hours: 4.0, pauses: 3, source: "merged" },                      // 07-02 Last-14 start boundary
-        { job: "Wolf", day: shift_day(now, -14), hours: 8.0, pauses: 0, source: "merged" },                      // 07-01 outside Last-14
-        { job: "Vega", day: shift_day(now, -25), hours: 1.0, pauses: 0, source: "merged" },                      // 06-20 Last-3-months only
+        { job: "Juno", day: shift_day(now, -13), hours: 4.0, pauses: 3, source: "merged" },                      // 07-02 inside default window
+        { job: "Wolf", day: shift_day(now, -27), hours: 8.0, pauses: 0, source: "merged" },                      // 06-18 Last-4-Weeks start boundary
+        { job: "Vega", day: shift_day(now, -35), hours: 1.0, pauses: 0, source: "merged" },                      // 06-10 outside the default window
     ];
 
     let line = 0;
@@ -199,7 +199,7 @@ export function build_filter_fixture(now: Date = FIXED_NOW): FilterFixtureData {
     return {
         payload: events.slice().sort((a, b) => b.timestamp - a.timestamp),
         jobs: plan.map(s => s.job),
-        jobs_in_last_14: plan.filter(s => s.day >= shift_day(now, -13)).map(s => s.job),
+        jobs_in_default_range: plan.filter(s => s.day >= shift_day(now, -27)).map(s => s.job),
     };
 }
 

--- a/tests/webview/harness.ts
+++ b/tests/webview/harness.ts
@@ -18,7 +18,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { Page } from "@playwright/test";
 
-import { FixtureEvent } from "./fixtures";
+import { FixtureEvent, FIXED_NOW } from "./fixtures";
 
 const WEBVIEW_DIR = path.resolve(__dirname, "../../src/dashboard/webview");
 const VENDOR_DIR = path.resolve(__dirname, "vendor");
@@ -37,6 +37,7 @@ function harness_html(): string {
     html = html.replace(/<meta http-equiv="Content-Security-Policy"[^>]*>/, "");
     html = html.replace(/\$\{cssUri\}/g, "dashboard.css");
     html = html.replace(/\$\{jsUri\}/g, "dashboard.js");
+    html = html.replace(/\$\{filterStateUri\}/g, "filter_state.js");
     html = html.replace(/ nonce="\$\{nonce\}"/g, "");
     return html;
 }
@@ -51,6 +52,12 @@ export async function open_dashboard(page: Page, payload: FixtureEvent[], buildI
             return route.fulfill({
                 contentType: "text/javascript",
                 body: fs.readFileSync(path.join(WEBVIEW_DIR, "dashboard.js"), "utf8"),
+            });
+        }
+        if (url.endsWith("filter_state.js")) {
+            return route.fulfill({
+                contentType: "text/javascript",
+                body: fs.readFileSync(path.join(WEBVIEW_DIR, "filter_state.js"), "utf8"),
             });
         }
         if (url.endsWith("dashboard.css")) {
@@ -91,8 +98,12 @@ export async function open_dashboard(page: Page, payload: FixtureEvent[], buildI
         });
     }, { fixturePayload: payload, fixtureBuildInfo: buildInfo });
 
+    // Freeze the page clock to the same instant the fixtures are built around,
+    // so relative date presets resolve deterministically (no midnight flake).
+    await page.clock.setFixedTime(FIXED_NOW);
+
     await page.goto(DASHBOARD_URL);
-    // Dashboard is ready once the job filter has rendered
+    // Dashboard is ready once the job filter legend has rendered
     await page.waitForSelector("#job_all_checkbox");
 }
 

--- a/tests/webview/harness.ts
+++ b/tests/webview/harness.ts
@@ -84,6 +84,20 @@ export async function open_dashboard(page: Page, payload: FixtureEvent[], buildI
 
     await page.addInitScript(({ fixturePayload, fixtureBuildInfo }: { fixturePayload: FixtureEvent[]; fixtureBuildInfo?: string }) => {
         const w = window as any;
+
+        // Disable Chart.js animations the moment the CDN script assigns the
+        // global — geometry is final immediately, so pixel-level interaction
+        // tests (bar clicks) are deterministic instead of racing the tween.
+        let chart_global: any;
+        Object.defineProperty(w, "Chart", {
+            configurable: true,
+            get() { return chart_global; },
+            set(v) {
+                chart_global = v;
+                if (v && v.defaults) v.defaults.animation = false;
+            },
+        });
+
         w.__posted = [];
         w.__reply = (msg: unknown) => window.postMessage(msg, "*");
         w.acquireVsCodeApi = () => ({


### PR DESCRIPTION
Closes #5. Replaces the dashboard's filter sidebar with filtering and sorting integrated into the summary view, driven by one filter state.

## User-facing behavior

- **Date bar** (global): quick presets — Today, This Week, Last 7/14 Days, **Last 4 Weeks (default, actually applied on load — fixes the old never-applied "Today" default, #31)**, This Month, Last 3 Months, Last Year, All — plus native start/end date pickers. Presets fill the fields; hand-editing flips to Custom; first date entered fills both (single-day rule).
- **Job legend** beside the pie: bold names with per-job hour totals in grey, color swatches, checkboxes, "All", scrollable, tooltips for long names. Synced both ways with the Job column's filter menu.
- **Excel-style column headers** in the Session Log (renamed from "Raw Sessions"): click to sort with direction indicators; funnel menus on Job / Duration / Pause-Resume ("P/R" with tooltip) with inclusive min/max ranges, per-column Clear, funnels light up when active. Range values commit on Enter or blur — never mid-typing.
- Charts and table always agree: every filter drives both. Prominent "No data in the selected date range or filters" message replaces the pie when nothing matches.
- Edit modal: **Enter saves, Escape cancels.**
- Colorblind/contrast-validated 10-color palette with stable per-job colors (aesthetic revisit tracked in #44).
- `npm run seed-testdata`: ~6 months of realistic history (hierarchical job titles, free-text tasks matched to the real store's measured profile), plus `-- --from-real` to copy your actual global store (honoring `timescope.global_storage_dir`) into the isolated test storage.

## Technical

```mermaid
flowchart LR
    FS["filter_state.js<br>(pure: presets, ranges,<br>jobs, source, sort)"] --> DJ["dashboard.js<br>(one filter_state object)"]
    DJ --> P[Pie + legend]
    DJ --> B[Stacked bar]
    DJ --> T[Session Log table]
    NT["src/test/test_filter_state.ts<br>(pure-Node suite)"] -.requires.-> FS
    PW["tests/webview/*.spec.ts<br>(39 Playwright tests)"] -.drives.-> DJ
```

- New pure module `filter_state.js` loads in the webview **and** the Node test suite; date presets resolve to explicit day bounds; `source` (merged/global/workspace) is wired through the filter model as the seam for #3 (no UI yet).
- Job/task names HTML-escaped everywhere (job names are user input — injection regression-tested); range inputs debounce-free via commit-on-Enter; delegated event handling; chart chrome reads CSS tokens.
- Tests: frozen `page.clock` (kills the midnight fixture flake), 12-job boundary fixture, data-level chart assertions incl. a real pixel-click highlight test, DST-boundary preset tests, hostile-name injection test. Chart animations disabled in the harness for determinism.
- Version 0.3.2 → **0.4.0** (confirmed). No dependency or other `package.json` changes.

Decision log: [docs/dev-log/issue-5-log-filtering.md](https://github.com/Heliman84/timescope/blob/feature/issue-5-log-filtering/docs/dev-log/issue-5-log-filtering.md) — including the three real-data F5 rounds that reshaped the filter UX, and spawned follow-ups #42/#43/#44/#45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)