### PR TITLE
Playwright coverage for malformed event streams in the dashboard (#42 webview)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ One line per merged PR, added at PR time under **Unreleased**. At release, entri
 
 ## Unreleased
 
+- Playwright coverage pinning how the dashboard renders malformed/unbalanced event streams (dangling start, unresumed pause, orphan resume, stop-without-start, double start) — production reality per the real log's 145/122 pause/resume imbalance (#42)
 - Docs: introduce `docs/arc-log/` for multi-issue development arcs (spine above the per-issue dev-logs); first entry documents the local-first storage re-architecture (#42, #48)
 - Log hygiene: newline-safe appends (concatenated-record bug class closed), load-time sanitizer that heals glued records in memory and reports damage, atomic temp-file+rename for all full-file rewrites, and a **TimeScope: Compact Log** command (`.bak` first, idempotent) offered via prompt when disk damage is found; `npm run seed-testdata -- --damaged` seeds a damaged log for F5 testing (#42)
 - Summary view redesign: sidebar replaced by integrated filtering — date presets (default Last 14 Days, now actually applied) with native start/end date pickers, a checkbox job legend synced with a table job dropdown, inclusive duration and pause/resume range filters, sortable columns, an explicit empty state, and a validated colorblind-safe chart palette; all filters drive the charts and table together (#5)

--- a/docs/dev-log/issue-42-webview-malformed-streams.md
+++ b/docs/dev-log/issue-42-webview-malformed-streams.md
@@ -1,7 +1,7 @@
 # Issue #42 — Webview malformed-stream coverage (42b: webview track)
 
 > Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
-> Part of the [Local-First Storage arc](../arc-log/local-first-storage.md) (Wave 1).
+> Part of the [Local-First Storage arc](../arc-log/arc-local-first-storage.md) (Wave 1).
 
 **Issue:** https://github.com/Heliman84/timescope/issues/42  ·  **PR:** https://github.com/Heliman84/timescope/pull/50
 

--- a/docs/dev-log/issue-42-webview-malformed-streams.md
+++ b/docs/dev-log/issue-42-webview-malformed-streams.md
@@ -2,7 +2,7 @@
 
 > Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
 
-**Issue:** https://github.com/Heliman84/timescope/issues/42  ·  **PR:** (pending)
+**Issue:** https://github.com/Heliman84/timescope/issues/42  ·  **PR:** https://github.com/Heliman84/timescope/pull/50
 
 ## Problem
 

--- a/docs/dev-log/issue-42-webview-malformed-streams.md
+++ b/docs/dev-log/issue-42-webview-malformed-streams.md
@@ -1,6 +1,7 @@
 # Issue #42 — Webview malformed-stream coverage (42b: webview track)
 
 > Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
+> Part of the [Local-First Storage arc](../arc-log/local-first-storage.md) (Wave 1).
 
 **Issue:** https://github.com/Heliman84/timescope/issues/42  ·  **PR:** https://github.com/Heliman84/timescope/pull/50
 

--- a/docs/dev-log/issue-42-webview-malformed-streams.md
+++ b/docs/dev-log/issue-42-webview-malformed-streams.md
@@ -36,4 +36,9 @@ double start. This branch is the webview half of #42, run in parallel with the s
 
 ## Retrospective
 
-(filled at PR time)
+Landed exactly as planned: `build_malformed_fixture` (five isolated single-purpose jobs) +
+four specs pinning all five behaviors from the issue checklist. All passed on first run —
+expected for characterization tests — and code review found no defects (column indices,
+substring-collision safety, and the 10:00 cross-job timestamp tie were all checked and hold).
+No product code touched; the webview-drops / Node-finalizes divergence for dangling sessions
+is now documented here and asserted on the webview side.

--- a/docs/dev-log/issue-42-webview-malformed-streams.md
+++ b/docs/dev-log/issue-42-webview-malformed-streams.md
@@ -1,0 +1,39 @@
+# Issue #42 — Webview malformed-stream coverage (42b: webview track)
+
+> Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
+
+**Issue:** https://github.com/Heliman84/timescope/issues/42  ·  **PR:** (pending)
+
+## Problem
+
+The dashboard's `build_sessions_from_events` (dashboard.js) runs its own state machine over raw
+event streams, and malformed/unbalanced streams are production reality (real log: 145 pause vs
+122 resume). Its tolerances were undocumented and untested — nothing pinned how the dashboard
+renders a dangling start, an unresumed pause, an orphan resume, a stop without a start, or a
+double start. This branch is the webview half of #42, run in parallel with the storage half (42a).
+
+## Decisions & trade-offs
+
+- **Pure test addition** — no product code changes. The current tolerances (verified by reading
+  the state machine) are reasonable and now become pinned behavior:
+  - dangling start → session dropped (explicit comment in code: open sessions are ignored)
+  - pause never resumed → paused tail excluded from duration; **no** pause pair counted
+  - resume without pause → ignored entirely
+  - stop without start → ignored entirely
+  - double start → first session finalized *at the second start's timestamp*, task taken from
+    the first start event
+- One fixture (`build_malformed_fixture`) with five single-purpose jobs (Dangle, Orphan, Skip,
+  Ghost, Twice) so each scenario's state machine is isolated per job — mirrors the existing
+  `build_filter_fixture` style.
+- All events placed "today" relative to `FIXED_NOW` so the default Last-4-Weeks preset never
+  interferes with row counts.
+
+## Rejected approaches
+
+- Asserting through the Node-side `EventRepository.loadSessions` too — that path already has
+  unit coverage and (deliberately) differs: it *finalizes* dangling sessions, the webview drops
+  them. The divergence is now documented here rather than papered over.
+
+## Retrospective
+
+(filled at PR time)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "TimeScope",
     "description": "A VS Code extension for tracking work sessions with analytics and a dashboard.",
     "publisher": "davidclass",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "engines": {
         "vscode": "^1.85.0"
     },

--- a/tests/webview/fixtures.ts
+++ b/tests/webview/fixtures.ts
@@ -209,3 +209,71 @@ function shift_day(now: Date, delta_days: number): string {
     d.setDate(now.getDate() + delta_days);
     return local_day(d.getTime());
 }
+
+export interface MalformedFixtureData {
+    payload: FixtureEvent[];
+    /** Jobs that must produce at least one session row. */
+    jobs_with_sessions: string[];
+    /** Jobs whose events must produce no session at all. */
+    jobs_without_sessions: string[];
+}
+
+/**
+ * Malformed / unbalanced event streams — production reality (the real log
+ * carries 145 pause vs 122 resume events). One single-purpose job per
+ * scenario so each state machine is isolated (all "today", inside the
+ * default Last-4-Weeks preset):
+ *
+ * - Dangle: start with no stop            → session dropped (intentional)
+ * - Orphan: pause never resumed, then stop → paused tail excluded, no pair
+ * - Skip:   resume without a pause         → resume ignored
+ * - Ghost:  stop without a start           → ignored
+ * - Twice:  double start, then stop        → first session finalized at the
+ *                                            second start's timestamp
+ */
+export function build_malformed_fixture(now: Date = FIXED_NOW): MalformedFixtureData {
+    let line = 0;
+    const ev = (
+        event: string,
+        job: string,
+        job_id: string,
+        hours: number,
+        minutes: number,
+        task = ""
+    ): FixtureEvent => ({
+        event,
+        job,
+        timestamp: at_local_time(now, hours, minutes),
+        task,
+        id: `mf-${++line}`,
+        job_id,
+        time_seed: at_local_time(now, hours, minutes),
+        global_line_index: line,
+        workspace_line_index: line,
+    });
+
+    const events: FixtureEvent[] = [
+        // Dangle: start with no stop — the dashboard drops open sessions
+        ev("start", "Dangle", "dangle", 8, 0, "dangle work"),
+        // Orphan: 09:00–10:00 with a pause at 09:30 never resumed → 0.50h active, 0 pairs
+        ev("start", "Orphan", "orphan", 9, 0),
+        ev("pause", "Orphan", "orphan", 9, 30),
+        ev("stop", "Orphan", "orphan", 10, 0, "orphan work"),
+        // Skip: 10:00–11:00 with a resume at 10:30 that had no pause → 1.00h, 0 pairs
+        ev("start", "Skip", "skip", 10, 0),
+        ev("resume", "Skip", "skip", 10, 30),
+        ev("stop", "Skip", "skip", 11, 0, "skip work"),
+        // Ghost: stop with no start — ignored
+        ev("stop", "Ghost", "ghost", 12, 30, "ghost work"),
+        // Twice: starts at 13:00 and again at 14:00, stop at 15:30
+        ev("start", "Twice", "twice", 13, 0, "twice-first"),
+        ev("start", "Twice", "twice", 14, 0, "twice-second"),
+        ev("stop", "Twice", "twice", 15, 30, "twice-stop"),
+    ];
+
+    return {
+        payload: events.slice().sort((a, b) => b.timestamp - a.timestamp),
+        jobs_with_sessions: ["Orphan", "Skip", "Twice"],
+        jobs_without_sessions: ["Dangle", "Ghost"],
+    };
+}

--- a/tests/webview/malformed_streams.spec.ts
+++ b/tests/webview/malformed_streams.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+
+import { build_malformed_fixture, MalformedFixtureData } from "./fixtures";
+import { open_dashboard } from "./harness";
+
+// Pins how build_sessions_from_events (dashboard.js) renders malformed /
+// unbalanced event streams — production reality (the real log carries 145
+// pause vs 122 resume events). Scenarios per issue #42's test-coverage note;
+// one single-purpose job per scenario, all "today" relative to FIXED_NOW.
+//
+// Note the deliberate divergence from the Node side: EventRepository
+// finalizes dangling sessions; the webview drops them.
+
+let fx: MalformedFixtureData;
+
+test.beforeEach(async ({ page }) => {
+    fx = build_malformed_fixture();
+    await open_dashboard(page, fx.payload);
+});
+
+test("dangling start and stop-without-start produce no sessions", async ({ page }) => {
+    // Orphan + Skip + Twice's two sessions = 4 rows; Dangle and Ghost nowhere.
+    const rows = page.locator("#session_table_body tr");
+    await expect(rows).toHaveCount(4);
+    for (const job of fx.jobs_without_sessions) {
+        await expect(page.locator("#session_table_body")).not.toContainText(job);
+    }
+
+    // Legend and pie only know the jobs that produced sessions.
+    await expect(page.locator("#job_legend .legend-job-box")).toHaveCount(3);
+    const pie_labels = await page.evaluate(() => (window as any).Chart.getChart("pie_chart")?.data.labels);
+    expect(pie_labels?.slice().sort()).toEqual(["Orphan", "Skip", "Twice"]);
+});
+
+test("pause never resumed: paused tail excluded from duration, no pair counted", async ({ page }) => {
+    // Orphan 09:00–10:00, paused at 09:30 with no resume → 0.50h active.
+    const row = page.locator("#session_table_body tr", { hasText: "orphan work" });
+    await expect(row.locator("td").nth(2)).toHaveText("0.50h");
+    // The dangling pause is NOT a pause/resume pair.
+    await expect(row.locator("td").nth(6)).toHaveText("0");
+});
+
+test("resume without a pause is ignored", async ({ page }) => {
+    // Skip 10:00–11:00 with an orphan resume at 10:30 → full 1.00h, no pairs.
+    const row = page.locator("#session_table_body tr", { hasText: "skip work" });
+    await expect(row.locator("td").nth(2)).toHaveText("1.00h");
+    await expect(row.locator("td").nth(6)).toHaveText("0");
+});
+
+test("double start finalizes the first session at the second start", async ({ page }) => {
+    // Twice: start 13:00, start 14:00, stop 15:30 → two sessions.
+    // First session 13:00–14:00 (task from its start event), second 14:00–15:30.
+    const first = page.locator("#session_table_body tr", { hasText: "twice-first" });
+    await expect(first).toHaveCount(1);
+    await expect(first.locator("td").nth(2)).toHaveText("1.00h");
+
+    const second = page.locator("#session_table_body tr", { hasText: "twice-stop" });
+    await expect(second).toHaveCount(1);
+    await expect(second.locator("td").nth(2)).toHaveText("1.50h");
+
+    // Table is newest-first: the 14:00 session outranks the 13:00 one.
+    const rows = page.locator("#session_table_body tr");
+    await expect(rows.nth(0)).toContainText("twice-stop");
+    await expect(rows.nth(1)).toContainText("twice-first");
+});


### PR DESCRIPTION
Part 2 of 2 for #42 (webview track; parallel to #49). Pure test addition — no product code.

Pins `build_sessions_from_events`' tolerances for malformed/unbalanced streams (production reality: the real log carries 145 pause vs 122 resume events):

| Stream shape | Pinned behavior |
| :--- | :--- |
| dangling `start` (no stop) | session dropped (webview intentionally ignores open sessions — the Node side finalizes them; divergence now documented) |
| `pause` never resumed | paused tail excluded from duration, **no** pause pair counted |
| `resume` without a pause | ignored |
| `stop` without a start | ignored |
| double `start` | first session finalized at the second start's timestamp, task from the first start |

New `build_malformed_fixture` (five isolated single-purpose jobs) + `tests/webview/malformed_streams.spec.ts` (4 specs). Full suite: 43/43.

Merge after #49, then this branch bumps 0.5.0 → 0.5.1 (test-only patch, per the agreed sequence).

Closes #42

Dev log: [docs/dev-log/issue-42-webview-malformed-streams.md](docs/dev-log/issue-42-webview-malformed-streams.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)