### PR TITLE
docs: fill in PR #58 link in issue-56 dev-log

### DIFF
--- a/docs/dev-log/issue-56-agent-process.md
+++ b/docs/dev-log/issue-56-agent-process.md
@@ -3,7 +3,7 @@
 > Decision log, not a spec. Started at plan time, finalized as a retrospective at PR time.
 > Keep it short — capture the *why*, not a blow-by-blow. Skip any section that doesn't apply.
 
-**Issue:** [#56](https://github.com/Heliman84/timescope/issues/56)  ·  **PR:** *pending*
+**Issue:** [#56](https://github.com/Heliman84/timescope/issues/56)  ·  **PR:** [#58](https://github.com/Heliman84/timescope/pull/58)
 
 
 ## Problem


### PR DESCRIPTION
One-line fix: the issue-56 dev-log's PR field was still *pending* at merge time — set it to #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)